### PR TITLE
Attestation: Changes for detecting LLDP IP

### DIFF
--- a/src/provisioning_object.hpp
+++ b/src/provisioning_object.hpp
@@ -46,7 +46,7 @@ struct ProvisioningController : Ifaces
     PeerConnectionStatus peerConnected() const override
     {
         LOG_DEBUG("PeerConnected state {}",
-                  static_cast<int>(trustedConnectionState));
+                  convertPeerConnectionStatusToString(trustedConnectionState));
         return trustedConnectionState;
     }
     bool provisioned() const override
@@ -56,7 +56,8 @@ struct ProvisioningController : Ifaces
     }
     void setPeerConnected(PeerConnectionStatus value)
     {
-        LOG_DEBUG("Setting PeerConnected state {}", static_cast<int>(value));
+        LOG_DEBUG("Setting PeerConnected state {}",
+                  convertPeerConnectionStatusToString(value));
         trustedConnectionState = value;
         Ifaces::peerConnected(value, false);
     }

--- a/subdir/attestationd/conf/spdm.conf
+++ b/subdir/attestationd/conf/spdm.conf
@@ -7,7 +7,6 @@
     "sign-cert": "/etc/ssl/certs/https/server.mtls.pem",
     "verify-cert": "/etc/ssl/certs/bmc.ca.pem",
     "port": "8080",
-    "ip": "164.10.10.10",
     "remote_ip":"164.10.10.11",
     "remote_port": "8080",
     "prefix": "/tmp/",

--- a/subdir/attestationd/src/spdmdeviceiface.hpp
+++ b/subdir/attestationd/src/spdmdeviceiface.hpp
@@ -39,6 +39,10 @@ struct SpdmDeviceIface
         iface->register_signal<bool>(signalName); // signal name
         iface->initialize();
     }
+    ~SpdmDeviceIface()
+    {
+        dbusServer.remove_interface(iface);
+    }
     void setAttestationStartHandler(AFTERATTESTATION_HANDLER handler)
     {
         onAttestationStart = std::move(handler);


### PR DESCRIPTION
Attestation will use IP address from LLDP packet to detect remote device