### PR TITLE
provisioningd: add top-level meson.build to enable build

### DIFF
--- a/conf/provisioning.conf
+++ b/conf/provisioning.conf
@@ -1,0 +1,7 @@
+{
+    "port":8090,
+    "cert_root":"/tmp/",
+    "retry_count":3,
+    "retry_timer":30,
+    "interface_id":"eth1"
+}

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,40 @@
+project('provisioningd', 'cpp',default_options: ['cpp_std=c++23','buildtype=debugoptimized',])
+boost_dep = dependency('boost', modules: ['url'], required: true)
+openssl_dep = dependency('openssl', required: true)
+sdeventplus_dep = dependency('sdeventplus')
+sdbusplus_dep =dependency('sdbusplus')
+dbus_interfaces_dep =dependency('phosphor-dbus-interfaces')
+provisioning_dep = declare_dependency(
+    dependencies:[sdbusplus_dep,sdeventplus_dep,openssl_dep,boost_dep,dbus_interfaces_dep],
+    include_directories:['include']
+)
+provisioning_default_busname = 'xyz.openbmc_project.Provisioning'
+configure_file(
+    input: 'service/xyz.openbmc_project.provisioning.service.in',
+    output: 'xyz.openbmc_project.provisioning.service',
+    configuration: {
+        'SYSTEMD_TARGET': 'multi-user.target',
+        'DEFAULT_BUSNAME': provisioning_default_busname,
+    },
+    install: true,
+    install_dir: dependency('systemd').get_variable('systemdsystemunitdir'),
+)
+executable('provisioningd',
+  ['src/provisioningd.cpp',
+  ],
+  install: true,
+  include_directories:['src'],
+  cpp_args: ['-DBOOST_ASIO_DISABLE_THREADS'],
+  dependencies:provisioning_dep,
+  install_dir: '/usr/bin'
+)
+
+install_data('service/xyz.openbmc_project.provisioning.conf',
+  install_dir:'/etc/dbus-1/system.d/'
+)
+
+install_data(
+    'conf/provisioning.conf',
+    install_dir: '/var/provisioning/',
+)
+subdir('subdir')

--- a/subdir/attestationd/conf/spdm.conf
+++ b/subdir/attestationd/conf/spdm.conf
@@ -1,18 +1,9 @@
 {
-    "server-cert": "/etc/ssl/certs/https/server.mtls.pem",
-    "server-pkey": "/etc/ssl/private/server.mtls.key",
-    "client-cert": "/etc/ssl/certs/https/client.mtls.pem",
-    "client-pkey": "/etc/ssl/private/client.mtls.key",
-    "sign-privkey": "/etc/ssl/private/server.mtls.key",
-    "sign-cert": "/etc/ssl/certs/https/server.mtls.pem",
-    "verify-cert": "/etc/ssl/certs/bmc.ca.pem",
     "port": "8080",
-    "remote_ip":"164.10.10.11",
-    "remote_port": "8080",
-    "prefix": "/tmp/",
+    "exchange_prefix": "/tmp/",
+    "interface_id":"eth1",
     "resources": [
        "/usr/bin/attestationd",
        "/usr/bin/provisioningd"
-
     ]
 }


### PR DESCRIPTION
Add a top-level meson.build to include the provisioningd service in the build system and provide the required stub components. This enables provisioningd to be built and packaged as part of the OpenBMC image.

No functional changes; build-only additions.