### PR TITLE
attestation: generate self-signed root certificate

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('provisioningd', 'cpp',default_options: ['cpp_std=c++23','buildtype=debugoptimized',])
 boost_dep = dependency('boost', modules: ['url'], required: true)
-openssl_dep = dependency('openssl', required: true)
+openssl_dep = dependency('openssl', version: '>= 3.0', required: true)
 sdeventplus_dep = dependency('sdeventplus')
 sdbusplus_dep =dependency('sdbusplus')
 dbus_interfaces_dep =dependency('phosphor-dbus-interfaces')

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,6 @@
+option(
+    'attestation_stub',
+    type: 'boolean',
+    description: 'Enables attestation stub',
+    value:true
+)

--- a/src/provisioningd.cpp
+++ b/src/provisioningd.cpp
@@ -1,4 +1,5 @@
 #include "bmcresponder.hpp"
+#include "cert_generator.hpp"
 #include "command_line_parser.hpp"
 #include "dbusproperty_watcher.hpp"
 #include "provisioning_object.hpp"
@@ -275,6 +276,7 @@ int main(int argc, const char* argv[])
     {
         auto& logger = getLogger();
         logger.setLogLevel(LogLevel::DEBUG);
+        Tpm2::getInstance(); // Initialize TPM2 provider
         net::io_context io_context;
         std::ifstream confFile("/var/provisioning/provisioning.conf");
         auto confJson = nlohmann::json::parse(confFile);

--- a/subdir/attestationd/conf/spdm.conf
+++ b/subdir/attestationd/conf/spdm.conf
@@ -1,5 +1,6 @@
 {
     "port": "8080",
+    "self-signed": true,
     "exchange_prefix": "/tmp/",
     "interface_id":"eth1",
     "resources": [

--- a/subdir/attestationd/src/root_certs.hpp
+++ b/subdir/attestationd/src/root_certs.hpp
@@ -1,0 +1,95 @@
+#pragma once
+#include "cert_generator.hpp"
+
+using namespace NSNAME;
+constexpr auto CLIENT_PKEY_NAME = "/etc/ssl/private/client.mtls.key";
+constexpr auto ENTITY_CLIENT_CERT_NAME = "/etc/ssl/certs/https/client.mtls.pem";
+constexpr auto SERVER_PKEY_NAME = "/etc/ssl/private/server.mtls.key";
+constexpr auto ENTITY_SERVER_CERT_NAME = "/etc/ssl/certs/https/server.mtls.pem";
+constexpr auto CA_CERT_NAME = "/etc/ssl/certs/bmc.ca.pem";
+constexpr auto CA_KEY_NAME = "/etc/ssl/private/bmc.ca.key";
+constexpr auto SIGNING_CERT_NAME = "/etc/ssl/certs/https/signing.pem";
+constexpr auto SIGNING_KEY_NAME = "/etc/ssl/private/signing.key";
+
+bool processInterMediateCA(const openssl_ptr<EVP_PKEY, EVP_PKEY_free>& pkey,
+                           const openssl_ptr<X509, X509_free>& ca)
+{
+    if (!pkey)
+    {
+        LOG_ERROR("Failed to read private key from provided data");
+        return false;
+    }
+    if (!ca)
+    {
+        LOG_ERROR("Failed to read CA certificate from provided data");
+        return false;
+    }
+    std::array<ENTITY_DATA, 3> entity_data = {
+        ENTITY_DATA{"clientAuth", std::format(CLIENT_PKEY_NAME),
+                    std::format(ENTITY_CLIENT_CERT_NAME)},
+        ENTITY_DATA{"serverAuth", std::format(SERVER_PKEY_NAME),
+                    std::format(ENTITY_SERVER_CERT_NAME)},
+        ENTITY_DATA{"signing", std::format(SIGNING_KEY_NAME),
+                    std::format(SIGNING_CERT_NAME)}};
+    auto certsdata = createAndSaveEntityCertificate<3>(pkey, ca, "BMC Entity",
+                                                       entity_data, 1);
+    if (!certsdata)
+    {
+        LOG_ERROR("Failed to create server entity certificate");
+        return false;
+    }
+    auto [serverCert, serverKey] = std::move(*certsdata);
+
+    // auto serverCert = loadCertificate(ENTITY_SERVER_CERT_NAME);
+    if (!isSignedByCA(serverCert, getPublicKeyFromCert(ca)))
+    {
+        LOG_ERROR("Failed to verify signature of server certificate");
+    }
+    auto clientCertsdata = createAndSaveEntityCertificate<3>(
+        pkey, ca, "BMC Entity", entity_data, 0);
+    if (!clientCertsdata)
+    {
+        LOG_ERROR("Failed to create client entity certificate");
+        return false;
+    }
+    auto signCertData = createAndSaveEntityCertificate<3>(
+        pkey, ca, "BMC Entity", entity_data, 2);
+    if (!signCertData)
+    {
+        LOG_ERROR("Failed to create signing certificate");
+        return false;
+    }
+    auto [clientCert, clientKey] = std::move(*clientCertsdata);
+
+    // auto clientCert = loadCertificate(ENTITY_CLIENT_CERT_NAME);
+    if (!isSignedByCA(clientCert, getPublicKeyFromCert(ca)))
+    {
+        LOG_ERROR("Failed to verify signature of  client certificate");
+    }
+
+    return true;
+}
+bool ensureCertificates(const std::string& verify_cert, bool selfsigned)
+{
+    if (std::filesystem::exists(verify_cert))
+    {
+        LOG_DEBUG("Certificate file {} does exist", verify_cert);
+        return true;
+    }
+    if (selfsigned)
+    {
+        auto [ca, pkey] = create_ca_cert(nullptr, nullptr, "BMC CA");
+        if (!ca || !pkey)
+        {
+            throw std::runtime_error(
+                "Failed to create CA certificate and private key");
+        }
+        if (!processInterMediateCA(pkey, ca))
+        {
+            throw std::runtime_error("Failed to create entity certificates");
+        }
+        saveCertificate(CA_CERT_NAME, ca, true);
+        savePrivateKey(CA_KEY_NAME, pkey, true);
+    }
+    return selfsigned;
+}

--- a/subdir/meson.build
+++ b/subdir/meson.build
@@ -1,1 +1,3 @@
-subdir('attestationd')
+if (get_option('attestation_stub') == true)
+    subdir('attestationd')
+endif


### PR DESCRIPTION
Generate and install a self-signed root certificate when no system root CA is present. This provides a fallback for attestation flows so attestation does not fail on systems that lack a pre-provisioned root certificate.

The self-signed certificate is only created if no valid root certificate is found, preserving existing behavior on systems with an existing CA.