### PR TITLE
provisioning: take hardcoded defaults for configuration

### DIFF
--- a/src/provisioningd.cpp
+++ b/src/provisioningd.cpp
@@ -269,7 +269,16 @@ net::awaitable<void> startSpdm(
         LOG_ERROR("SPDM provisioning failed {}", e.what());
     }
 }
-
+nlohmann::json loadConfig(const std::string& configPath)
+{
+    std::ifstream confFile(configPath);
+    if (confFile)
+    {
+        return nlohmann::json::parse(confFile);
+    }
+    return nlohmann::json{
+        {"port", 8090}, {"cert_root", "/tmp/1222/"}, {"interface_id", "eth1"}};
+}
 int main(int argc, const char* argv[])
 {
     try
@@ -278,8 +287,8 @@ int main(int argc, const char* argv[])
         logger.setLogLevel(LogLevel::DEBUG);
         Tpm2::getInstance(); // Initialize TPM2 provider
         net::io_context io_context;
-        std::ifstream confFile("/var/provisioning/provisioning.conf");
-        auto confJson = nlohmann::json::parse(confFile);
+
+        auto confJson = loadConfig("/var/provisioning/provisioning.conf");
         auto port = confJson.value("port", 8090);
         cert_root = confJson.value("cert_root", std::string{"/tmp/1222/"});
         auto iface = confJson.value("interface_id", std::string{"eth2"});

--- a/subdir/attestationd/src/spdmlite.cpp
+++ b/subdir/attestationd/src/spdmlite.cpp
@@ -204,7 +204,28 @@ net::awaitable<void> updateNeighbourDetails(
                                                    responderInfo, spdmHandler);
     intialiseSpdmHandler(spdmHandler, *spdmDevice, spdmResponder);
 }
-
+nlohmann::json loadConfig(const std::string& configPath)
+{
+    std::ifstream confFile(configPath);
+    if (confFile)
+    {
+        return nlohmann::json::parse(confFile);
+    }
+    return nlohmann::json{
+        {"server-cert", std::string{"/etc/ssl/certs/https/server.mtls.pem"}},
+        {"server-pkey", std::string{"/etc/ssl/private/server.mtls.key"}},
+        {"client-cert", std::string{"/etc/ssl/certs/https/client.mtls.pem"}},
+        {"client-pkey", std::string{"/etc/ssl/private/client.mtls.key"}},
+        {"sign-privkey", std::string{"/etc/ssl/private/signing.key"}},
+        {"sign-cert", std::string{"/etc/ssl/certs/https/signing.pem"}},
+        {"verify-cert", std::string{"/etc/ssl/certs/bmc.ca.pem"}},
+        {"self-signed", true},
+        {"port", std::string{"8091"}},
+        {"ip", std::string{"0.0.0.0"}},
+        {"interface_id", std::string{"eth1"}},
+        {"exchange_prefix", std::string{"/"}},
+        {"resources", nlohmann::json::array()}};
+}
 int main(int argc, const char* argv[])
 {
     auto [conf] = getArgs(parseCommandline(argc, argv), "--conf,-c");
@@ -217,7 +238,7 @@ int main(int argc, const char* argv[])
     }
     try
     {
-        auto json = nlohmann::json::parse(std::ifstream(conf.value().data()));
+        auto json = loadConfig(conf.value().data());
 
         auto servercert = json.value(
             "server-cert", std::string{"/etc/ssl/certs/https/server.mtls.pem"});


### PR DESCRIPTION
Use hardcoded defaults in case of configuration file missing cases.