### PR TITLE
self-provision: add local provisioning for BMC0

### DIFF
--- a/src/provisioningd.cpp
+++ b/src/provisioningd.cpp
@@ -31,7 +31,6 @@ static constexpr auto LLDP_INTF = "xyz.openbmc_project.Network.LLDP.TLVs";
 static constexpr auto LLDP_PROP = "ManagementAddressIPv4";
 static constexpr auto LLDP_REC_PATH =
     "/xyz/openbmc_project/network/lldp/{}/receive";
-
 using DbusObjectPath = std::string;
 using DbusInterface = std::string;
 using PropertyValue = std::string;


### PR DESCRIPTION
Provide a way to provision BMC0 without relying on a peer BMC. Introduce a custom command that bypasses the D-Bus interface so provisioning can run in early or isolated environments.

Add a file-monitor mechanism that watches for a self-provision trigger file. Manufacturing workflows can create this trigger via bmcshell TACF (Targeted ACF) to initiate self-provisioning, ensuring the current BMC becomes provisioned without peer interaction.