### PR TITLE
attestationd: Sanitize device names and add debug logging

### DIFF
--- a/subdir/attestationd/src/attestation.cpp
+++ b/subdir/attestationd/src/attestation.cpp
@@ -137,7 +137,9 @@ auto createNeighbourHandler(
             remotePort](const std::string& address,
                         const std::string& name) -> net::awaitable<void> {
         LOG_INFO("Neighbour LLDP Address : {} Name : {} ", address, name);
-        AttestationDeviceIface::ResponderInfo responderInfo{name, address,
+        std::string sanitizedName = name;
+        std::replace(sanitizedName.begin(), sanitizedName.end(), '-', '_');
+        AttestationDeviceIface::ResponderInfo responderInfo{sanitizedName, address,
                                                             remotePort};
         attestationDevice.reset();
         attestationDevice = std::make_shared<AttestationDeviceIface>(

--- a/subdir/attestationd/src/attestationdeviceiface.hpp
+++ b/subdir/attestationd/src/attestationdeviceiface.hpp
@@ -28,7 +28,9 @@ struct AttestationDeviceIface
         conn(conn), dbusServer(dbusServer), responderInfo(rInfo),
         attestationHandler(handler)
     {
+        
         auto ifacePath = std::format(objPath, responderInfo.id);
+        LOG_DEBUG("Creatign request at {}",ifacePath);
         iface = dbusServer.add_interface(ifacePath, interface);
         // test generic properties
         iface->register_method("attest", [this]() { attest(); });
@@ -38,7 +40,9 @@ struct AttestationDeviceIface
         iface->register_property("remote_port", responderInfo.eport,
                                  sdbusplus::asio::PropertyPermission::readOnly);
         iface->register_signal<bool>(signalName); // signal name
+        LOG_DEBUG("Intialising iface");
         iface->initialize();
+        LOG_DEBUG("Attestation requester iface created");
     }
     ~AttestationDeviceIface()
     {


### PR DESCRIPTION
Sanitize responder device names by replacing hyphens with underscores to ensure D-Bus object path compatibility. D-Bus object paths cannot contain hyphens, which can cause interface creation failures.

Also add debug logging to track attestation interface creation and initialization for better troubleshooting.

Changes:
- Replace hyphens with underscores in neighbour device names
- Add debug logs for interface path creation
- Add debug logs for interface initialization
- Add debug log confirming successful interface creation

Tested:
- Verified attestation interface creation with device names containing hyphens
- Confirmed D-Bus object paths are created successfully