### PR TITLE
Track bidirectional peer connection states separately

### DIFF
--- a/include/lldp_neighbour_handlers.hpp
+++ b/include/lldp_neighbour_handlers.hpp
@@ -34,9 +34,10 @@ static constexpr auto LLDP_INTF = "xyz.openbmc_project.Network.LLDP.TLVs";
  * @return A coroutine handler for D-Bus signal processing
  */
 template <typename Handler>
-auto makeNeighbourDiscoveryHandler(Handler handler)
+auto makeNeighbourDiscoveryHandler(Handler handler,
+                                   std::function<void()> fallback = {})
 {
-    return [handler = std::move(handler)](
+    return [handler = std::move(handler), fallback = std::move(fallback)](
                const boost::system::error_code& ec,
                std::optional<sdbusplus::message_t> m) -> net::awaitable<void> {
         if (!m)
@@ -66,6 +67,11 @@ auto makeNeighbourDiscoveryHandler(Handler handler)
         if (address.empty() || name.empty())
         {
             LOG_ERROR("LLDP Address or Name is empty");
+            if (fallback)
+            {
+                LOG_DEBUG("Calling fallback for fetching Address");
+                fallback();
+            }
             co_return;
         }
 

--- a/src/provisioning_object.hpp
+++ b/src/provisioning_object.hpp
@@ -24,8 +24,14 @@ struct ProvisioningController : Ifaces
 {
     net::io_context& ioContext;
     std::shared_ptr<sdbusplus::asio::connection> conn;
-    PeerConnectionStatus trustedConnectionState{
-        PeerConnectionStatus::NotDetermined};
+    enum class ConnectionDirection
+    {
+        incoming=0,
+        outgoing
+    };
+   
+    std::array<PeerConnectionStatus,2> trustedConnectionState{
+        PeerConnectionStatus::NotDetermined,PeerConnectionStatus::NotDetermined};
     bool provState{false};
     using PROVISIONING_HANDLER = std::function<void(const std::string&)>;
     PROVISIONING_HANDLER provisionHandler;
@@ -67,26 +73,49 @@ struct ProvisioningController : Ifaces
     }
     PeerConnectionStatus peerConnected() const override
     {
+        auto state=getHighestTrustedConnectionState();
         LOG_DEBUG("PeerConnected state {}",
-                  convertPeerConnectionStatusToString(trustedConnectionState));
-        return trustedConnectionState;
+                  convertPeerConnectionStatusToString(state));
+        return state;
     }
     bool provisioned() const override
     {
         LOG_DEBUG("Provisioned state {}", provState);
         return provState;
     }
-    void setPeerConnected(PeerConnectionStatus value)
+    void setPeerConnected(PeerConnectionStatus value,ConnectionDirection dir)
     {
         LOG_DEBUG("Setting PeerConnected state {}",
                   convertPeerConnectionStatusToString(value));
-        trustedConnectionState = value;
-        Ifaces::peerConnected(value, false);
+        trustedConnectionState[static_cast<size_t>(dir)] = value;
+        Ifaces::peerConnected(getHighestTrustedConnectionState(), false);
     }
     void setProvisioned(bool value)
     {
         LOG_DEBUG("Setting Provisioned state {}", value);
         provState = value;
         Ifaces::provisioned(value, false);
+    }
+
+  private:
+    /**
+     * @brief Determines the highest value in trustedConnectionState entries
+     * @return The highest PeerConnectionStatus value from the array
+     */
+    PeerConnectionStatus getHighestTrustedConnectionState() const
+    {
+        auto incomingState = trustedConnectionState[static_cast<size_t>(ConnectionDirection::incoming)];
+        auto outgoingState = trustedConnectionState[static_cast<size_t>(ConnectionDirection::outgoing)];
+        
+        LOG_DEBUG("Incoming connection state: {}",
+                  convertPeerConnectionStatusToString(incomingState));
+        LOG_DEBUG("Outgoing connection state: {}",
+                  convertPeerConnectionStatusToString(outgoingState));
+        
+        auto highestState = std::max(incomingState, outgoingState);
+        LOG_DEBUG("Highest connection state: {}",
+                  convertPeerConnectionStatusToString(highestState));
+        
+        return highestState;
     }
 };

--- a/src/provisioningd.cpp
+++ b/src/provisioningd.cpp
@@ -131,30 +131,33 @@ net::awaitable<void> tryConnect(net::io_context& io_context,
                                 const std::string& ip, short port,
                                 ProvisioningController& controller)
 {
+    auto dir=ProvisioningController::ConnectionDirection::outgoing;
     controller.setPeerConnected(
-        ProvisioningIface::PeerConnectionStatus::InProgress);
+        ProvisioningIface::PeerConnectionStatus::InProgress,dir);
     LOG_DEBUG("Trying peer connection");
     auto sslCtx = getClientContext();
+    
     if (!sslCtx)
     {
         LOG_ERROR("ssl context is not available");
         controller.setPeerConnected(
-            ProvisioningIface::PeerConnectionStatus::NotConnected);
+            ProvisioningIface::PeerConnectionStatus::NotConnected,dir);
         co_return;
     }
     TcpClient client(io_context.get_executor(), *sslCtx);
     auto ec = co_await connect(client, ip, port);
+    
     if (ec)
     {
         controller.setPeerConnected(
-            ProvisioningIface::PeerConnectionStatus::NotConnected);
+            ProvisioningIface::PeerConnectionStatus::NotConnected,dir);
         co_return;
     }
     controller.setPeerConnected(
-        ProvisioningIface::PeerConnectionStatus::Connected);
+        ProvisioningIface::PeerConnectionStatus::Connected,dir);
     co_await monitorBmc(io_context, client);
     controller.setPeerConnected(
-        ProvisioningIface::PeerConnectionStatus::NotConnected);
+        ProvisioningIface::PeerConnectionStatus::NotConnected,dir);
 }
 
 std::shared_ptr<BmcResponder> makeBmcResponder(
@@ -167,7 +170,7 @@ std::shared_ptr<BmcResponder> makeBmcResponder(
     bmcResponder->onConnectionChange([&controller](bool connected) {
         controller.setPeerConnected(
             connected ? ProvisioningIface::PeerConnectionStatus::Connected
-                      : ProvisioningIface::PeerConnectionStatus::NotConnected);
+                      : ProvisioningIface::PeerConnectionStatus::NotConnected,ProvisioningController::ConnectionDirection::incoming);
     });
     return bmcResponder;
 }

--- a/subdir/attestationd/src/attestation.cpp
+++ b/subdir/attestationd/src/attestation.cpp
@@ -252,9 +252,13 @@ int main(int argc, const char* argv[])
         auto neighbourHandler = createNeighbourHandler(
             io_context, conn, dbusServer, attestationHandler,
             attestationResponder, attestationDevice, std::format("{}",port));
-
+        auto fallbackHandler = [&io_context,conn,iface,neighbourHandler](){
+            net::co_spawn(io_context,
+                      makeNeighbourUpdateHandler(conn, iface, neighbourHandler),
+                      net::detached);
+        };
         DbusSignalWatcher<sdbusplus::message_t>::watch(
-            io_context, conn, makeNeighbourDiscoveryHandler(neighbourHandler),
+            io_context, conn, makeNeighbourDiscoveryHandler(neighbourHandler,std::move(fallbackHandler)),
             sdbusplus::bus::match::rules::interfacesAddedAtPath(
                 std::format(LLDP_REC_PATH, iface)));
 


### PR DESCRIPTION
Add support for tracking incoming and outgoing peer connection states independently to provide more granular connection status monitoring.

Changes:
- Modified ProvisioningController to use array of connection states for incoming and outgoing directions
- Added ConnectionDirection enum to distinguish connection types
- Implemented getHighestTrustedConnectionState() to determine overall connection status from both directions
- Updated setPeerConnected() to accept ConnectionDirection parameter
- Modified all connection state updates in tryConnect() and makeBmcResponder() to specify connection direction
- Enhanced LLDP neighbour discovery handler with optional fallback callback for address resolution failures
- Added fallback handler in attestation.cpp to retry neighbour updates when LLDP address/name is empty

This allows the system to independently track and report the status of both incoming connections (from peers) and outgoing connections (to peers), providing better visibility into connection health.