### PR TITLE
provisioningd: Add purge mode and increase retry timeout

### DIFF
--- a/include/eventqueue.hpp
+++ b/include/eventqueue.hpp
@@ -64,6 +64,14 @@ struct EventQueue
     {
         return taskQueue.getEndPoint();
     }
+    void setPurgeMode(bool mode)
+    {
+        taskQueue.setPurgeMode(mode);
+    }
+    bool getPurgeMode() const
+    {
+        return taskQueue.getPurgeMode();
+    }
     void addEventProvider(const std::string& eventId,
                           EventProvider eventProvider)
     {
@@ -330,4 +338,4 @@ struct EventQueue
     JsonSerializer serializer;
     uint64_t lastBarrierTime{0};
 };
-}
+} // namespace NSNAME

--- a/include/taskqueue.hpp
+++ b/include/taskqueue.hpp
@@ -86,6 +86,14 @@ class TaskQueue
     {
         return endPoint;
     }
+    void setPurgeMode(bool mode)
+    {
+        purgeMode = mode;
+    }
+    bool getPurgeMode() const
+    {
+        return purgeMode;
+    }
     void addTask(Task messageHandler, bool front = false)
     {
         bool processNow = taskHandlers.size() < maxClients;
@@ -190,6 +198,11 @@ class TaskQueue
             }
             co_return NetworkTask{takeTask(), *client};
         }
+        if (purgeMode)
+        {
+            // delete the task if connection not available
+            takeTask();
+        }
         co_return std::nullopt;
     }
 
@@ -250,7 +263,7 @@ class TaskQueue
             }
             LOG_WARNING("Failed to connect to {}:{}. Retrying {}/{}",
                         endPoint.url, endPoint.port, i + 1, maxRetryCount);
-            timer.expires_after(5s);
+            timer.expires_after(30s);
             co_await timer.async_wait(net::use_awaitable);
             i++;
         }
@@ -267,5 +280,6 @@ class TaskQueue
     int maxRetryCount{3};
     size_t maxClients{1};
     bool started{false};
+    bool purgeMode{true};
 };
-}
+} // namespace NSNAME


### PR DESCRIPTION
Add purge mode functionality to TaskQueue and EventQueue to allow tasks to be discarded when no client connections are available. This prevents task queue buildup when the endpoint is unavailable.

Changes:
- Add setPurgeMode() and getPurgeMode() methods to TaskQueue
- Add setPurgeMode() and getPurgeMode() methods to EventQueue
- Implement task purging logic in getNextTask() when purgeMode is true
- Increase connection retry timeout from 5s to 30s for better stability
- Add namespace closing comments for better code clarity
- Initialize purgeMode to true by default

Tested: Verified task queue behavior with purge mode enabled/disabled