### PR TITLE
provisioningd: replace std::max with explicit maxStatus for peer state

### DIFF
--- a/src/provisioning_object.hpp
+++ b/src/provisioning_object.hpp
@@ -26,12 +26,13 @@ struct ProvisioningController : Ifaces
     std::shared_ptr<sdbusplus::asio::connection> conn;
     enum class ConnectionDirection
     {
-        incoming=0,
+        incoming = 0,
         outgoing
     };
-   
-    std::array<PeerConnectionStatus,2> trustedConnectionState{
-        PeerConnectionStatus::NotDetermined,PeerConnectionStatus::NotDetermined};
+
+    std::array<PeerConnectionStatus, 2> trustedConnectionState{
+        PeerConnectionStatus::NotDetermined,
+        PeerConnectionStatus::NotDetermined};
     bool provState{false};
     using PROVISIONING_HANDLER = std::function<void(const std::string&)>;
     PROVISIONING_HANDLER provisionHandler;
@@ -73,7 +74,7 @@ struct ProvisioningController : Ifaces
     }
     PeerConnectionStatus peerConnected() const override
     {
-        auto state=getHighestTrustedConnectionState();
+        auto state = getHighestTrustedConnectionState();
         LOG_DEBUG("PeerConnected state {}",
                   convertPeerConnectionStatusToString(state));
         return state;
@@ -83,7 +84,7 @@ struct ProvisioningController : Ifaces
         LOG_DEBUG("Provisioned state {}", provState);
         return provState;
     }
-    void setPeerConnected(PeerConnectionStatus value,ConnectionDirection dir)
+    void setPeerConnected(PeerConnectionStatus value, ConnectionDirection dir)
     {
         LOG_DEBUG("Setting PeerConnected state {}",
                   convertPeerConnectionStatusToString(value));
@@ -104,18 +105,40 @@ struct ProvisioningController : Ifaces
      */
     PeerConnectionStatus getHighestTrustedConnectionState() const
     {
-        auto incomingState = trustedConnectionState[static_cast<size_t>(ConnectionDirection::incoming)];
-        auto outgoingState = trustedConnectionState[static_cast<size_t>(ConnectionDirection::outgoing)];
-        
+        auto incomingState = trustedConnectionState[static_cast<size_t>(
+            ConnectionDirection::incoming)];
+        auto outgoingState = trustedConnectionState[static_cast<size_t>(
+            ConnectionDirection::outgoing)];
+
         LOG_DEBUG("Incoming connection state: {}",
                   convertPeerConnectionStatusToString(incomingState));
         LOG_DEBUG("Outgoing connection state: {}",
                   convertPeerConnectionStatusToString(outgoingState));
-        
-        auto highestState = std::max(incomingState, outgoingState);
+
+        auto highestState = maxStatus(incomingState, outgoingState);
         LOG_DEBUG("Highest connection state: {}",
                   convertPeerConnectionStatusToString(highestState));
-        
+
         return highestState;
+    }
+    PeerConnectionStatus maxStatus(PeerConnectionStatus first,
+                                   PeerConnectionStatus second) const
+    {
+        if (first == PeerConnectionStatus::Connected ||
+            second == PeerConnectionStatus::Connected)
+        {
+            return PeerConnectionStatus::Connected;
+        }
+        if (first == PeerConnectionStatus::InProgress ||
+            second == PeerConnectionStatus::InProgress)
+        {
+            return PeerConnectionStatus::InProgress;
+        }
+        if (first == PeerConnectionStatus::NotConnected ||
+            second == PeerConnectionStatus::NotConnected)
+        {
+            return PeerConnectionStatus::NotConnected;
+        }
+        return PeerConnectionStatus::NotDetermined;
     }
 };

--- a/src/provisioningd.cpp
+++ b/src/provisioningd.cpp
@@ -310,28 +310,31 @@ int main(int argc, const char* argv[])
                             std::ref(controller), std::ref(bmcResponder)),
             ATTESTATION_RES_INTF, ATTESTATION_RES_SIGNAL);
 
-        auto neighbourHandler = [&io_context, &controller,
-                                 port](const std::string& address,
-                                       const std::string& name) -> net::awaitable<void> {
-            co_await onNeighbourFound(io_context, controller, port, address, name);
+        auto neighbourHandler =
+            [&io_context, &controller,
+             port](const std::string& address,
+                   const std::string& name) -> net::awaitable<void> {
+            co_await onNeighbourFound(io_context, controller, port, address,
+                                      name);
         };
 
         auto fallbackHandler = [&io_context, conn, iface, neighbourHandler]() {
-            net::co_spawn(io_context,
-                          makeNeighbourUpdateHandler(conn, iface, neighbourHandler),
-                          net::detached);
+            net::co_spawn(
+                io_context,
+                makeNeighbourUpdateHandler(conn, iface, neighbourHandler),
+                net::detached);
         };
 
         DbusSignalWatcher<sdbusplus::message_t>::watch(
             io_context, conn,
-            makeNeighbourDiscoveryHandler(neighbourHandler, std::move(fallbackHandler)),
+            makeNeighbourDiscoveryHandler(neighbourHandler,
+                                          std::move(fallbackHandler)),
             sdbusplus::bus::match::rules::interfacesAddedAtPath(
                 std::format(LLDP_REC_PATH, iface)));
 
-        net::co_spawn(
-            io_context,
-            makeNeighbourUpdateHandler(conn, iface, neighbourHandler),
-            net::detached);
+        net::co_spawn(io_context,
+                      makeNeighbourUpdateHandler(conn, iface, neighbourHandler),
+                      net::detached);
         io_context.run();
     }
     catch (const std::exception& e)


### PR DESCRIPTION
std::max on PeerConnectionStatus relied on the underlying enum integer ordering to determine the highest connection state. This is fragile: the result depends on the declaration order of enum values rather than any explicit priority contract.

Replace the std::max call in getHighestTrustedConnectionState() with a new private maxStatus() helper that explicitly encodes the priority:
  Connected > InProgress > NotConnected > NotDetermined

This makes the intent clear and decouples the logic from enum value ordering.

Also apply clang-format fixes to provisioning_object.hpp and provisioningd.cpp.