### PR TITLE
provisioningd: Add connection delay and reduce debug logging

### DIFF
--- a/src/provisioning_object.hpp
+++ b/src/provisioning_object.hpp
@@ -109,12 +109,12 @@ struct ProvisioningController : Ifaces
             ConnectionDirection::incoming)];
         auto outgoingState = trustedConnectionState[static_cast<size_t>(
             ConnectionDirection::outgoing)];
-
+#if 0
         LOG_DEBUG("Incoming connection state: {}",
                   convertPeerConnectionStatusToString(incomingState));
         LOG_DEBUG("Outgoing connection state: {}",
                   convertPeerConnectionStatusToString(outgoingState));
-
+#endif
         auto highestState = maxStatus(incomingState, outgoingState);
         LOG_DEBUG("Highest connection state: {}",
                   convertPeerConnectionStatusToString(highestState));

--- a/src/provisioningd.cpp
+++ b/src/provisioningd.cpp
@@ -184,6 +184,7 @@ net::awaitable<void> onNeighbourFound(
         LOG_INFO("Peer already connected, skipping connection attempt");
         co_return;
     }
+    co_await waitFor(io_context, 15s);
     co_await tryConnect(io_context, address, rport, controller);
     co_return;
 }


### PR DESCRIPTION
- Added 15 second wait before attempting peer connection to allow network stabilization
- Commented out verbose connection state debug logs to reduce log noise during normal operation

The delay helps prevent premature connection attempts when peers are discovered but not yet ready to accept connections.

Tested: Verified peer connections establish successfully with delay