### PR TITLE
provisioningd: Add network monitoring service with ping test

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -37,4 +37,30 @@ install_data(
     'conf/provisioning.conf',
     install_dir: '/var/provisioning/',
 )
+
+
+if (get_option('pingtest') == true)
+    # Install network monitor script
+    install_data(
+        'service/simple-fix-minimal.sh',
+        install_dir: '/usr/bin',
+        install_mode: 'rwxr-xr-x'
+    )
+    # Configure and install network monitor service
+    configure_file(
+        input: 'service/network-monitor.service.in',
+        output: 'network-monitor.service',
+        configuration: {
+            'SYSTEMD_TARGET': 'multi-user.target',
+            'CHECK_INTERVAL': '30',
+        },
+        install: true,
+        install_dir: dependency('systemd').get_variable('systemdsystemunitdir'),
+    )
+endif
 subdir('subdir')
+
+# Include tests if enabled
+if get_option('tests').enabled()
+    subdir('test')
+endif

--- a/meson.options
+++ b/meson.options
@@ -4,3 +4,17 @@ option(
     description: 'Enables attestation stub',
     value:true
 )
+
+option(
+    'pingtest',
+    type: 'boolean',
+    description: 'Enables pingtest tool',
+    value:true
+)
+
+option(
+    'tests',
+    type: 'feature',
+    description: 'Build unit tests',
+    value: 'auto'
+)

--- a/service/network-monitor.service.in
+++ b/service/network-monitor.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Network Monitor and Recovery Service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/bin/simple-fix-minimal.sh @CHECK_INTERVAL@
+Restart=always
+Type=simple
+
+[Install]
+WantedBy=@SYSTEMD_TARGET@

--- a/service/simple-fix-minimal.sh
+++ b/service/simple-fix-minimal.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+# Configuration
+PF="/run/openbmc/bmc_position"
+INT="${CHECK_INTERVAL:-30}"
+IF="eth2"
+IP="9.6.28.10"
+
+# Get target IP based on BMC position
+get_ip() {
+    [ ! -f "$PF" ] && return 1
+    P=$(cat "$PF" 2>/dev/null)
+    [ "$P" -eq 0 ] && D=1 || D=0
+    TIP="${IP}${D}"
+    return 0
+}
+
+# Test connectivity to target IP
+ping_test() {
+    ip neigh flush dev "$IF" 2>/dev/null
+    sleep 1
+    ping -I "$IF" -c 2 -W 2 "$TIP" &>/dev/null
+}
+
+# Recover network interface
+recover() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Ping failed! Recovering..."
+    ip link set "$IF" promisc on
+    ip link set "$IF" down
+    sleep 2
+    ip link set "$IF" up
+    sleep 3
+    
+    if ping_test; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] Recovery OK"
+        return 0
+    else
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] Recovery failed"
+        return 1
+    fi
+}
+
+# Main monitoring loop
+while true; do
+    if get_ip; then
+        if ! ping_test; then
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] Ping failed to $TIP (Pos:$P)"
+            recover
+        fi
+    fi
+    sleep "$INT"
+done
+


### PR DESCRIPTION
Add a network monitoring service that periodically checks network connectivity and performs automatic recovery when needed. This includes:

- Add 'pingtest' meson option to enable/disable the feature
- Install network-monitor systemd service when pingtest is enabled
- Add simple-fix-minimal.sh script for network monitoring and recovery
- Configure service with customizable check interval and systemd target
- Add test subdirectory support in meson build

The network monitor reads BMC position from /run/openbmc/bmc_position and pings the peer BMC on eth2 interface. If ping fails, it attempts recovery by enabling promiscuous mode and restarting the interface.

Tested: Built with pingtest option enabled and verified service installation.