### PR TITLE
provisioningd: Move config path from /var to /etc

### DIFF
--- a/service/xyz.openbmc_project.provisioning.service.in
+++ b/service/xyz.openbmc_project.provisioning.service.in
@@ -2,7 +2,7 @@
 Description=Provisioning D-Bus Service
 
 [Service]
-ExecStart=/usr/bin/provisioningd -c /var/provisioning/provisioning.conf
+ExecStart=/usr/bin/provisioningd -c /etc/provisioning/provisioning.conf
 Restart=always
 Type=dbus
 BusName=@DEFAULT_BUSNAME@

--- a/src/provisioningd.cpp
+++ b/src/provisioningd.cpp
@@ -268,6 +268,14 @@ nlohmann::json loadConfig(const std::string& configPath)
 }
 int main(int argc, const char* argv[])
 {
+    auto [conf] = getArgs(parseCommandline(argc, argv), "--conf,-c");
+    if (!conf)
+    {
+        LOG_ERROR(
+            "No config file provided :eg provisioningd --conf /path/to/conf");
+
+        return 1;
+    }
     try
     {
         auto& logger = getLogger();
@@ -275,7 +283,7 @@ int main(int argc, const char* argv[])
         Tpm2::getInstance(); // Initialize TPM2 provider
         net::io_context io_context;
 
-        auto confJson = loadConfig("/var/provisioning/provisioning.conf");
+        auto confJson = loadConfig(conf.value().data());
         auto port = confJson.value("port", 8090);
         cert_root = confJson.value("cert_root", std::string{"/"});
         auto iface = confJson.value("interface_id", std::string{"eth2"});

--- a/subdir/attestationd/service/xyz.openbmc_project.attestation.service.in
+++ b/subdir/attestationd/service/xyz.openbmc_project.attestation.service.in
@@ -2,7 +2,7 @@
 Description=attestation service
 
 [Service]
-ExecStart=/usr/bin/attestationd -c /var/attestation/attestation.conf
+ExecStart=/usr/bin/attestationd -c /etc/attestation/attestation.conf
 Restart=always
 Type=dbus
 BusName=@DEFAULT_BUSNAME@

--- a/subdir/attestationd/src/attestation.cpp
+++ b/subdir/attestationd/src/attestation.cpp
@@ -139,8 +139,8 @@ auto createNeighbourHandler(
         LOG_INFO("Neighbour LLDP Address : {} Name : {} ", address, name);
         std::string sanitizedName = name;
         std::replace(sanitizedName.begin(), sanitizedName.end(), '-', '_');
-        AttestationDeviceIface::ResponderInfo responderInfo{sanitizedName, address,
-                                                            remotePort};
+        AttestationDeviceIface::ResponderInfo responderInfo{
+            sanitizedName, address, remotePort};
         attestationDevice.reset();
         attestationDevice = std::make_shared<AttestationDeviceIface>(
             conn, dbusServer, responderInfo, attestationHandler);
@@ -220,8 +220,8 @@ int main(int argc, const char* argv[])
             loadClientContext(clientcert, clientprivkey, caCert, self_signed);
         auto serverCtx =
             loadServerContext(servercert, serverprivkey, caCert, self_signed);
-        TcpStreamType acceptor(io_context.get_executor(), myip,
-                               port, serverCtx);
+        TcpStreamType acceptor(io_context.get_executor(), myip, port,
+                               serverCtx);
         EventQueue eventQueue(io_context.get_executor(), acceptor,
                               ssl_client_context, maxConnections);
         auto conn = std::make_shared<sdbusplus::asio::connection>(io_context);
@@ -251,14 +251,17 @@ int main(int argc, const char* argv[])
 
         auto neighbourHandler = createNeighbourHandler(
             io_context, conn, dbusServer, attestationHandler,
-            attestationResponder, attestationDevice, std::format("{}",port));
-        auto fallbackHandler = [&io_context,conn,iface,neighbourHandler](){
-            net::co_spawn(io_context,
-                      makeNeighbourUpdateHandler(conn, iface, neighbourHandler),
-                      net::detached);
+            attestationResponder, attestationDevice, std::format("{}", port));
+        auto fallbackHandler = [&io_context, conn, iface, neighbourHandler]() {
+            net::co_spawn(
+                io_context,
+                makeNeighbourUpdateHandler(conn, iface, neighbourHandler),
+                net::detached);
         };
         DbusSignalWatcher<sdbusplus::message_t>::watch(
-            io_context, conn, makeNeighbourDiscoveryHandler(neighbourHandler,std::move(fallbackHandler)),
+            io_context, conn,
+            makeNeighbourDiscoveryHandler(neighbourHandler,
+                                          std::move(fallbackHandler)),
             sdbusplus::bus::match::rules::interfacesAddedAtPath(
                 std::format(LLDP_REC_PATH, iface)));
 


### PR DESCRIPTION
Move configuration file paths from /var to /etc for both provisioningd and attestationd services to follow standard Linux filesystem hierarchy conventions.

Changes:
- Update provisioningd service to use /etc/provisioning/provisioning.conf
- Update attestationd service to use /etc/attestation/attestation.conf
- Add config file validation in provisioningd main()
- Fix code formatting in attestation.cpp

Tested: Verified services start with new config paths