### PR TITLE
attestationd: Use hardcoded peer name for LLDP neighbors

### DIFF
--- a/subdir/attestationd/src/attestation.cpp
+++ b/subdir/attestationd/src/attestation.cpp
@@ -137,7 +137,7 @@ auto createNeighbourHandler(
             remotePort](const std::string& address,
                         const std::string& name) -> net::awaitable<void> {
         LOG_INFO("Neighbour LLDP Address : {} Name : {} ", address, name);
-        std::string sanitizedName = name;
+        std::string sanitizedName = "peer";
         std::replace(sanitizedName.begin(), sanitizedName.end(), '-', '_');
         AttestationDeviceIface::ResponderInfo responderInfo{
             sanitizedName, address, remotePort};


### PR DESCRIPTION
Change the neighbor handler to use a hardcoded 'peer' name instead of the dynamic name from LLDP. This ensures consistent naming for responder info regardless of the actual neighbor name.