### PR TITLE
provisioningd: Fix error handling in BmcResponder

### DIFF
--- a/src/bmcresponder.hpp
+++ b/src/bmcresponder.hpp
@@ -33,16 +33,16 @@ struct BmcResponder
             std::tie(ec, bytes) = co_await streamer.read(net::buffer(data));
             if (ec)
             {
-                if (ec == boost::asio::error::eof)
-                {
-                    LOG_ERROR("Error reading: {}", ec.message());
-                    watcherCallback(false);
-                    co_return;
-                }
                 if (ec == boost::asio::error::operation_aborted)
                 {
                     continue;
                 }
+                LOG_ERROR("Error reading: {}", ec.message());
+                if (watcherCallback)
+                {
+                    watcherCallback(false);
+                }
+                co_return;
             }
 
             LOG_INFO("Received: {}", std::string(data.data(), bytes));


### PR DESCRIPTION
Improve error handling logic in BmcResponder read operation:
- Remove special case for EOF error that was redundant
- Check operation_aborted before logging other errors
- Add null check for watcherCallback before invoking
- Consolidate error logging and callback invocation

This ensures proper cleanup and prevents potential null pointer dereference when watcherCallback is not set.

Tested: Verified error handling paths work correctly