### PR TITLE
provisioningd: Fix use-after-free and missing co_return

### DIFF
--- a/include/dbusproperty_watcher.hpp
+++ b/include/dbusproperty_watcher.hpp
@@ -49,12 +49,18 @@ struct DbusWatcher : std::enable_shared_from_this<Derived>
     void startTimeout(net::steady_timer& timer, std::chrono::seconds timeout)
     {
         timer.expires_after(timeout);
-        timer.async_wait([this](const boost::system::error_code& ec) {
+        // Use weak_ptr to avoid use-after-free if watcher is destroyed
+        // while timer callback is queued or executing
+        std::weak_ptr<Derived> weak = derived().shared_from_this();
+        timer.async_wait([weak](const boost::system::error_code& ec) {
             if (!ec)
             {
-                cancelWatch();
-                LOG_ERROR(
-                    "Timeout occurred while waiting for SPDM property change");
+                if (auto self = weak.lock())
+                {
+                    self->cancelWatch();
+                    LOG_ERROR(
+                        "Timeout occurred while waiting for SPDM property change");
+                }
             }
         });
     }

--- a/src/provisioningd.cpp
+++ b/src/provisioningd.cpp
@@ -291,6 +291,7 @@ net::awaitable<void> startSpdm(
         if (ec)
         {
             LOG_ERROR("Failed to start spdm: {}", ec.message());
+            co_return;
         }
 
         auto watcher = DbusSignalWatcher<bool>::create(


### PR DESCRIPTION
Fix use-after-free vulnerability in DbusWatcher timer callback by using weak_ptr to safely handle cases where the watcher is destroyed while the timer callback is queued or executing.

Add missing co_return in startSpdm error path to properly exit the coroutine when SPDM initialization fails.

Tested: Verified timer callbacks handle destroyed watchers safely
        and error paths properly exit coroutines.