### PR TITLE
provisioningd: Add runtime log level control via D-Bus

### DIFF
--- a/include/debug_controller.hpp
+++ b/include/debug_controller.hpp
@@ -1,0 +1,162 @@
+#pragma once
+#include "logger.hpp"
+
+#include <sdbusplus/asio/object_server.hpp>
+#include <sdbusplus/bus.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <memory>
+#include <optional>
+#include <string>
+
+using namespace reactor;
+
+/**
+ * @brief Controller for managing debug log levels via D-Bus
+ *
+ * This class provides a D-Bus interface to dynamically change the log level
+ * of the provisioning daemon at runtime without requiring a restart.
+ */
+class DebugController
+{
+  public:
+    static constexpr auto objPath = "/xyz/openbmc_project/Debug";
+    static constexpr auto interface =
+        "xyz.openbmc_project.Provisioning.DebugControl";
+
+    DebugController() = delete;
+    ~DebugController() = default;
+    DebugController(const DebugController&) = delete;
+    DebugController& operator=(const DebugController&) = delete;
+    DebugController(DebugController&&) = delete;
+    DebugController& operator=(DebugController&&) = delete;
+
+    /**
+     * @brief Construct a new Debug Controller object
+     *
+     * @param conn D-Bus connection
+     * @param objServer Object server for registering D-Bus interfaces
+     */
+    DebugController(std::shared_ptr<sdbusplus::asio::connection> conn,
+                    std::shared_ptr<sdbusplus::asio::object_server> objServer) :
+        conn(conn), objServer(objServer)
+    {
+        // Create the D-Bus interface
+        iface = objServer->add_interface(objPath, interface);
+
+        // Register SetLogLevel method
+        iface->register_method("SetLogLevel",
+                               [this](const std::string& level) -> bool {
+                                   return this->setLogLevel(level);
+                               });
+
+        // Register GetLogLevel method
+        iface->register_method("GetLogLevel", [this]() -> std::string {
+            return this->getLogLevel();
+        });
+
+        // Initialize the interface
+        iface->initialize();
+
+        LOG_INFO("DebugController initialized at {}", objPath);
+    }
+
+  private:
+    std::shared_ptr<sdbusplus::asio::connection> conn;
+    std::shared_ptr<sdbusplus::asio::object_server> objServer;
+    std::shared_ptr<sdbusplus::asio::dbus_interface> iface;
+
+    /**
+     * @brief Convert string to LogLevel enum
+     *
+     * @param levelStr String representation of log level
+     * @return std::optional<LogLevel> LogLevel if valid, nullopt otherwise
+     */
+    std::optional<LogLevel> stringToLogLevel(const std::string& levelStr)
+    {
+        if (levelStr == "DEBUG")
+        {
+            return LogLevel::DEBUG;
+        }
+        else if (levelStr == "INFO")
+        {
+            return LogLevel::INFO;
+        }
+        else if (levelStr == "WARNING")
+        {
+            return LogLevel::WARNING;
+        }
+        else if (levelStr == "ERROR")
+        {
+            return LogLevel::ERROR;
+        }
+        else if (levelStr == "CRITICAL")
+        {
+            return LogLevel::CRITICAL;
+        }
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Convert LogLevel enum to string
+     *
+     * @param level LogLevel enum value
+     * @return std::string String representation of log level
+     */
+    std::string logLevelToString(LogLevel level)
+    {
+        switch (level)
+        {
+            case LogLevel::DEBUG:
+                return "DEBUG";
+            case LogLevel::INFO:
+                return "INFO";
+            case LogLevel::WARNING:
+                return "WARNING";
+            case LogLevel::ERROR:
+                return "ERROR";
+            case LogLevel::CRITICAL:
+                return "CRITICAL";
+            default:
+                return "UNKNOWN";
+        }
+    }
+
+    /**
+     * @brief Set the log level
+     *
+     * @param levelStr String representation of desired log level
+     * @return true if log level was successfully set
+     * @return false if invalid log level string provided
+     */
+    bool setLogLevel(const std::string& levelStr)
+    {
+        // Convert to uppercase for case-insensitive comparison
+        std::string upperLevel = levelStr;
+        std::transform(upperLevel.begin(), upperLevel.end(), upperLevel.begin(),
+                       [](unsigned char c) { return std::toupper(c); });
+
+        auto level = stringToLogLevel(upperLevel);
+        if (!level)
+        {
+            LOG_ERROR("Invalid log level: {}", levelStr);
+            return false;
+        }
+
+        getLogger().setLogLevel(*level);
+        LOG_INFO("Log level changed to: {}", upperLevel);
+        return true;
+    }
+
+    /**
+     * @brief Get the current log level
+     *
+     * @return std::string String representation of current log level
+     */
+    std::string getLogLevel()
+    {
+        LogLevel currentLevel = getLogger().getLogLevel();
+        return logLevelToString(currentLevel);
+    }
+};

--- a/include/logger.hpp
+++ b/include/logger.hpp
@@ -1,7 +1,7 @@
 #pragma once
-#include <systemd/sd-journal.h>
-
 #include "name_space.hpp"
+
+#include <systemd/sd-journal.h>
 
 #include <format>
 #include <iostream>
@@ -81,6 +81,11 @@ class Logger
     void setLogLevel(LogLevel level)
     {
         currentLogLevel = level;
+    }
+
+    LogLevel getLogLevel() const
+    {
+        return currentLogLevel;
     }
 
   private:

--- a/src/provisioningd.cpp
+++ b/src/provisioningd.cpp
@@ -2,6 +2,7 @@
 #include "cert_generator.hpp"
 #include "command_line_parser.hpp"
 #include "dbusproperty_watcher.hpp"
+#include "debug_controller.hpp"
 #include "lldp_neighbour_handlers.hpp"
 #include "provisioning_object.hpp"
 #include "ssl_functions.hpp"
@@ -291,6 +292,7 @@ net::awaitable<void> startSpdm(
         if (ec)
         {
             LOG_ERROR("Failed to start spdm: {}", ec.message());
+            controller.peerProvisioned(false);
             co_return;
         }
 
@@ -342,7 +344,7 @@ int main(int argc, const char* argv[])
     try
     {
         auto& logger = getLogger();
-        logger.setLogLevel(LogLevel::DEBUG);
+        logger.setLogLevel(LogLevel::WARNING);
         Tpm2::getInstance(); // Initialize TPM2 provider
         net::io_context io_context;
 
@@ -357,6 +359,13 @@ int main(int argc, const char* argv[])
         auto conn = std::make_shared<sdbusplus::asio::connection>(io_context);
         ProvisioningController controller(io_context, conn);
         conn->request_name(ProvisioningController::busName);
+
+        // Create object server for D-Bus interfaces
+        auto objServer = std::make_shared<sdbusplus::asio::object_server>(conn);
+
+        // Create debug controller for runtime log level control
+        DebugController debugController(conn, objServer);
+
         std::shared_ptr<BmcResponder> bmcResponder;
         auto sslCtx = getServerContext();
         if (sslCtx)

--- a/subdir/attestationd/src/attestation.cpp
+++ b/subdir/attestationd/src/attestation.cpp
@@ -6,6 +6,7 @@
 #include "certificate_exchange.hpp"
 #include "command_line_parser.hpp"
 #include "dbusproperty_watcher.hpp"
+#include "debug_controller.hpp"
 #include "eventmethods.hpp"
 #include "eventqueue.hpp"
 #include "lldp_neighbour_handlers.hpp"
@@ -107,20 +108,21 @@ void intialiseAttestationHandler(
     AttestationHandler& attestationHandler, AttestationDeviceIface& deviceIface,
     AttestationResponderIface& attestationResponder)
 {
-    attestationHandler.setAttestationFinishHandler(
-        [&](bool status, bool resp) -> net::awaitable<void> {
-            LOG_INFO("Attestation Handshake finished with status: {} resp {}",
-                     status, resp);
-            if (resp)
-            {
-                attestationResponder.emitStatus(status);
-            }
-            else
-            {
-                deviceIface.emitStatus(status);
-            }
-            co_return;
-        });
+    attestationHandler.setAttestationFinishHandler([&](bool status, bool resp)
+                                                       -> net::awaitable<void> {
+        LOG_INFO(
+            "Attestation Handshake finished with status: {} is-responder {}",
+            status, resp);
+        if (resp)
+        {
+            attestationResponder.emitStatus(status);
+        }
+        else
+        {
+            deviceIface.emitStatus(status);
+        }
+        co_return;
+    });
 }
 
 auto createNeighbourHandler(
@@ -209,7 +211,7 @@ int main(int argc, const char* argv[])
         auto maxConnections = 1;
 
         auto& logger = reactor::getLogger();
-        logger.setLogLevel(reactor::LogLevel::DEBUG);
+        logger.setLogLevel(reactor::LogLevel::WARNING);
         net::io_context io_context;
         if (!ensureCertificates(servercert, self_signed))
         {
@@ -245,6 +247,13 @@ int main(int argc, const char* argv[])
             }
         }
         sdbusplus::asio::object_server dbusServer(conn);
+
+        // Create object server for D-Bus interfaces
+        auto objServer = std::make_shared<sdbusplus::asio::object_server>(conn);
+
+        // Create debug controller for runtime log level control
+        DebugController debugController(conn, objServer);
+
         std::shared_ptr<AttestationDeviceIface> attestationDevice;
         AttestationResponderIface attestationResponder(conn, dbusServer,
                                                        "responder1");


### PR DESCRIPTION
Add DebugController class to enable dynamic log level changes at runtime without requiring daemon restart. This provides a D-Bus interface at /xyz/openbmc_project/Debug with methods to get and set log levels.

Changes:
- Add debug_controller.hpp with D-Bus interface for log level control
- Add getLogLevel() method to Logger class
- Integrate DebugController in provisioningd and attestationd
- Change default log level from DEBUG to WARNING
- Fix error handling in SPDM start failure path
- Improve attestation log message clarity

The D-Bus interface provides:
- SetLogLevel(string): Set log level (DEBUG/INFO/WARNING/ERROR/CRITICAL)
- GetLogLevel(): Get current log level

This allows operators to enable debug logging on-demand for troubleshooting without service interruption.

Tested: Verified log level can be changed via busctl and logging
        behavior changes accordingly