### PR TITLE
bmc-pairing-manager: Rename ProvisioningController to BmcPairingManag…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,26 @@
-# Provisioning 
+# BMC Pairing Manager
 ## Overview
 
-The Provisioning Daemon (`provisioningd`) is a secure BMC (Baseboard Management Controller) provisioning service that facilitates mutual authentication and secure communication between BMC peers using SPDM (Security Protocol and Data Model) attestation and SSL/TLS encrypted connections.
+The BMC Pairing Manager Daemon (`bmc-pairing-manager`) is a secure BMC (Baseboard Management Controller) pairing service that facilitates mutual authentication and secure communication between BMC peers using SPDM (Security Protocol and Data Model) attestation and SSL/TLS encrypted connections.
 
 ## Architecture Components
 
 ### Core Components
 
-1. **ProvisioningController**
-   - Central orchestrator managing provisioning state
-   - Exposes D-Bus interface for external control
-   - Tracks peer connection status and provisioning state
-   - Coordinates between SPDM attestation and secure connections
+1. **BmcPairingManagerObject**
+   - D-Bus object implementing the Provisioning interface for BMC pairing management
+   - Manages provisioning state through PicController integration
+   - Tracks bidirectional peer connection status (incoming/outgoing)
+   - Provides provisionPeer() method to initiate peer provisioning via D-Bus
+   - Exposes provisioned and peerConnected properties for monitoring pairing state
+   - Maintains connection state for both incoming (server) and outgoing (client) connections
+   - Determines highest connection state across both directions for unified status reporting
 
 2. **BmcResponder**
    - SSL/TLS server accepting incoming connections from peer BMCs
-   - Handles secure communication after successful provisioning
+   - Handles secure communication after successful pairing
    - Monitors connection health with keep-alive mechanism
-   - Dynamically recreates SSL context after SPDM provisioning
+   - Dynamically recreates SSL context after SPDM pairing
 
 3. **TcpClient**
    - SSL/TLS client for initiating connections to peer BMCs
@@ -58,8 +61,8 @@ The Provisioning Daemon (`provisioningd`) is a secure BMC (Baseboard Management 
 
 ```mermaid
 graph TB
-    subgraph "Provisioning Daemon"
-        PC[ProvisioningController]
+    subgraph "BMC Pairing Manager Daemon"
+        PC[BmcPairingManagerObject]
         BR[BmcResponder]
         TC[TcpClient]
         CM[Certificate Manager]
@@ -79,7 +82,7 @@ graph TB
     end
     
     subgraph "Peer BMC"
-        PEER[Peer BMC Provisioning Service]
+        PEER[Peer BMC Pairing Manager Service]
     end
     
     PC --> BR
@@ -109,7 +112,7 @@ graph TB
 sequenceDiagram
     participant Client
     participant Main
-    participant PC as ProvisioningController
+    participant PC as BmcPairingManagerObject
     participant LLDP as LLDP Watcher
     participant SPDM as SPDM Service
     participant TC as TcpClient
@@ -119,11 +122,11 @@ sequenceDiagram
     Main->>PC: Initialize
     Main->>BR: Start Server (port 8090)
 
-    alt Provision
-        Client->>PC: Trigger provisionPeer()
+    alt Pair
+        Client->>PC: Trigger pairPeer()
         PC->>SPDM: Start attestation
         SPDM-->>Client: Attestation signal (success)
-        Peer-->>PC: Update provisioned state
+        Peer-->>PC: Update paired state
         Main->>BR: Recreate SSL context
         Main->>TC: Connect to peer
         TC->>Peer: SSL handshake
@@ -164,14 +167,14 @@ sequenceDiagram
    
 ```
 
-## Provisioning Flow
+## Pairing Flow
 
 ```mermaid
 stateDiagram-v2
     [*] --> NotDetermined: Start Service
-    NotDetermined --> Attesting: Provision Peer
-    Attesting --> Provisioned: Attestation Success
-    Provisioned --> InProgress: Try Connecting  
+    NotDetermined --> Attesting: Pair Peer
+    Attesting --> Paired: Attestation Success
+    Paired --> InProgress: Try Connecting
     InProgress --> Connected: Connection Success
     InProgress --> NotConnected: Connection Failed
     Connected --> NotConnected: Connection Lost
@@ -236,8 +239,8 @@ graph LR
 - Connection state tracking
 
 ### 4. D-Bus Interface
-- Exposes provisioning status via D-Bus
-- Allows external control of provisioning process
+- Exposes pairing status via D-Bus
+- Allows external control of pairing process
 - Property change notifications
 - Signal-based event propagation
 
@@ -249,7 +252,7 @@ graph LR
 
 ## Configuration
 
-The daemon reads configuration from `/var/provisioning/provisioning.conf`:
+The daemon reads configuration from `/var/bmc-pairing-manager/bmc-pairing-manager.conf`:
 
 ```json
 {
@@ -270,44 +273,44 @@ The daemon reads configuration from `/var/provisioning/provisioning.conf`:
 ## D-Bus Interface
 
 ### Service Name
-`xyz.openbmc_project.Provisioning`
+`xyz.openbmc_project.BmcPairingManager`
 
 ### Object Path
-`/xyz/openbmc_project/Provisioning`
+`/xyz/openbmc_project/BmcPairingManager`
 
 ### Interface
-`xyz.openbmc_project.Provisioning.Provisioning`
+`xyz.openbmc_project.BmcPairingManager.BmcPairingManager`
 
 ### Methods
-- **provisionPeer(deviceId: string)**: Initiates provisioning for a specific device
+- **provisionPeer(deviceId: string)**: Initiates pairing for a specific device
 
 ### Properties
 - **peerConnected**: Connection status (NotDetermined, InProgress, Connected, NotConnected)
-- **provisioned**: Boolean indicating if provisioning is complete
+- **provisioned**: Boolean indicating if pairing is complete
 ## Usage Examples
 
-### Provisioning Commands
+### Pairing Commands
 
-To provision self:
+To pair self:
 ```bash
-busctl call xyz.openbmc_project.Provisioning /xyz/openbmc_project/Provisioning xyz.openbmc_project.Provisioning.Provisioning ProvisionPeer s self
+busctl call xyz.openbmc_project.BmcPairingManager /xyz/openbmc_project/BmcPairingManager xyz.openbmc_project.BmcPairingManager.BmcPairingManager ProvisionPeer s self
 ```
 
-To provision a peer (e.g., skiboards):
+To pair a peer (e.g., skiboards):
 ```bash
-busctl call xyz.openbmc_project.Provisioning /xyz/openbmc_project/Provisioning xyz.openbmc_project.Provisioning.Provisioning ProvisionPeer s skiboards
+busctl call xyz.openbmc_project.BmcPairingManager /xyz/openbmc_project/BmcPairingManager xyz.openbmc_project.BmcPairingManager.BmcPairingManager ProvisionPeer s skiboards
 ```
 
-### Checking Provisioning Status
+### Checking Pairing Status
 
-To check if provisioned:
+To check if paired:
 ```bash
-busctl get-property xyz.openbmc_project.Provisioning /xyz/openbmc_project/Provisioning xyz.openbmc_project.Provisioning.Provisioning provisioned
+busctl get-property xyz.openbmc_project.BmcPairingManager /xyz/openbmc_project/BmcPairingManager xyz.openbmc_project.BmcPairingManager.BmcPairingManager provisioned
 ```
 
 To check peer connection status:
 ```bash
-busctl get-property xyz.openbmc_project.Provisioning /xyz/openbmc_project/Provisioning xyz.openbmc_project.Provisioning.Provisioning peerConnected
+busctl get-property xyz.openbmc_project.BmcPairingManager /xyz/openbmc_project/BmcPairingManager xyz.openbmc_project.BmcPairingManager.BmcPairingManager peerConnected
 ```
 
 
@@ -320,7 +323,7 @@ busctl get-property xyz.openbmc_project.Provisioning /xyz/openbmc_project/Provis
 
 ### Attestation Errors
 - Failed attestation prevents connection establishment
-- Timeout during attestation marks peer as not provisioned
+- Timeout during attestation marks peer as not paired
 - D-Bus communication errors are logged and handled gracefully
 
 ## Dependencies

--- a/src/bmc_pairing_manager.cpp
+++ b/src/bmc_pairing_manager.cpp
@@ -1,10 +1,10 @@
+#include "bmc_pairing_manager_object.hpp"
 #include "bmcresponder.hpp"
 #include "cert_generator.hpp"
 #include "command_line_parser.hpp"
 #include "dbusproperty_watcher.hpp"
 #include "debug_controller.hpp"
 #include "lldp_neighbour_handlers.hpp"
-#include "provisioning_object.hpp"
 #include "ssl_functions.hpp"
 #include "tcp_client.hpp"
 #include "tcp_server.hpp"
@@ -187,9 +187,9 @@ net::awaitable<boost::system::error_code> connect(
 }
 net::awaitable<void> tryConnect(net::io_context& io_context,
                                 const std::string& ip, short port,
-                                ProvisioningController& controller)
+                                BmcPairingManagerObject& controller)
 {
-    auto dir = ProvisioningController::ConnectionDirection::outgoing;
+    auto dir = BmcPairingManagerObject::ConnectionDirection::outgoing;
     controller.setPeerConnected(
         ProvisioningIface::PeerConnectionStatus::InProgress, dir);
     LOG_DEBUG("Trying peer connection");
@@ -220,7 +220,7 @@ net::awaitable<void> tryConnect(net::io_context& io_context,
 
 std::shared_ptr<BmcResponder> makeBmcResponder(
     net::io_context& ctx, ssl::context sslCtx, short port,
-    ProvisioningController& controller)
+    BmcPairingManagerObject& controller)
 {
     auto bmcResponder =
         std::make_shared<BmcResponder>(ctx, std::move(sslCtx), port);
@@ -229,12 +229,12 @@ std::shared_ptr<BmcResponder> makeBmcResponder(
         controller.setPeerConnected(
             connected ? ProvisioningIface::PeerConnectionStatus::Connected
                       : ProvisioningIface::PeerConnectionStatus::NotConnected,
-            ProvisioningController::ConnectionDirection::incoming);
+            BmcPairingManagerObject::ConnectionDirection::incoming);
     });
     return bmcResponder;
 }
 net::awaitable<void> onNeighbourFound(
-    net::io_context& io_context, ProvisioningController& controller,
+    net::io_context& io_context, BmcPairingManagerObject& controller,
     short rport, const std::string& address, const std::string& name)
 {
     LOG_INFO("LLDP Neighbour IP found: {} Name: {}", address, name);
@@ -249,7 +249,8 @@ net::awaitable<void> onNeighbourFound(
     co_return;
 }
 net::awaitable<void> onSpdmStateChange(
-    net::io_context& io_context, short port, ProvisioningController& controller,
+    net::io_context& io_context, short port,
+    BmcPairingManagerObject& controller,
     std::shared_ptr<BmcResponder>& bmcResponder,
     const boost::system::error_code& ec, std::optional<bool> val)
 {
@@ -275,7 +276,7 @@ net::awaitable<void> onSpdmStateChange(
 }
 net::awaitable<void> startSpdm(
     std::shared_ptr<sdbusplus::asio::connection> conn, net::io_context& ioc,
-    short port, const std::string& iface, ProvisioningController& controller,
+    short port, const std::string& iface, BmcPairingManagerObject& controller,
     std::shared_ptr<BmcResponder>& bmcResponder, const std::string& deviceName)
 {
     try
@@ -357,8 +358,8 @@ int main(int argc, const char* argv[])
         gRetryTime = confJson.value("retry_timer", 30);
 
         auto conn = std::make_shared<sdbusplus::asio::connection>(io_context);
-        ProvisioningController controller(io_context, conn);
-        conn->request_name(ProvisioningController::busName);
+        BmcPairingManagerObject controller(io_context, conn);
+        conn->request_name(BmcPairingManagerObject::busName);
 
         // Create object server for D-Bus interfaces
         auto objServer = std::make_shared<sdbusplus::asio::object_server>(conn);

--- a/src/bmc_pairing_manager_object.hpp
+++ b/src/bmc_pairing_manager_object.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "logger.hpp"
 #include "pic_controller.hpp"
 #include "sdbus_calls.hpp"
 
@@ -21,7 +22,7 @@ using UnsupportedRequest =
     sdbusplus::xyz::openbmc_project::Common::Error::UnsupportedRequest;
 using NotAllowed = sdbusplus::xyz::openbmc_project::Common::Error::NotAllowed;
 
-struct ProvisioningController : Ifaces
+struct BmcPairingManagerObject : Ifaces
 {
     net::io_context& ioContext;
     std::shared_ptr<sdbusplus::asio::connection> conn;
@@ -42,14 +43,14 @@ struct ProvisioningController : Ifaces
     static constexpr auto objPath = "/xyz/openbmc_project/BmcPairingManager";
     static constexpr auto interface = Provisioning::interface;
 
-    ProvisioningController() = delete;
-    ~ProvisioningController() = default;
-    ProvisioningController(const ProvisioningController&) = delete;
-    ProvisioningController& operator=(const ProvisioningController&) = delete;
-    ProvisioningController(ProvisioningController&&) = delete;
-    ProvisioningController& operator=(ProvisioningController&&) = delete;
-    ProvisioningController(net::io_context& ctx,
-                           std::shared_ptr<sdbusplus::asio::connection> conn) :
+    BmcPairingManagerObject() = delete;
+    ~BmcPairingManagerObject() = default;
+    BmcPairingManagerObject(const BmcPairingManagerObject&) = delete;
+    BmcPairingManagerObject& operator=(const BmcPairingManagerObject&) = delete;
+    BmcPairingManagerObject(BmcPairingManagerObject&&) = delete;
+    BmcPairingManagerObject& operator=(BmcPairingManagerObject&&) = delete;
+    BmcPairingManagerObject(net::io_context& ctx,
+                            std::shared_ptr<sdbusplus::asio::connection> conn) :
         Ifaces(*conn, objPath, Ifaces::action::defer_emit), ioContext(ctx),
         conn(conn)
 


### PR DESCRIPTION
…erObject

Rename the ProvisioningController class to BmcPairingManagerObject to better reflect its role as a D-Bus object managing BMC pairing state. Also rename the header file from provisioning_object.hpp to bmc_pairing_manager_object.hpp for consistency.

Changes:
- Rename struct ProvisioningController to BmcPairingManagerObject
- Rename file provisioning_object.hpp to bmc_pairing_manager_object.hpp
- Update all references in bmc_pairing_manager.cpp
- Update documentation in README.md to reflect the new naming and provide accurate description of BmcPairingManagerObject's role as a D-Bus object implementing the Provisioning interface

Tested: Build successful with meson/ninja