### PR TITLE
bmc-pairing-manager: handle TLS handshake and message size failures

### DIFF
--- a/include/tcp_server.hpp
+++ b/include/tcp_server.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "logger.hpp"
 #include "make_awaitable.hpp"
 #include "socket_streams.hpp"
 
@@ -40,9 +41,16 @@ class TcpServer
     boost::asio::awaitable<void> handle_client(
         std::shared_ptr<boost::asio::ssl::stream<Socket>> socket)
     {
-        // Perform SSL handshake
-        co_await socket->async_handshake(boost::asio::ssl::stream_base::server,
-                                         boost::asio::use_awaitable);
+        // Perform SSL handshake with error handling
+        boost::system::error_code ec;
+        co_await socket->async_handshake(
+            boost::asio::ssl::stream_base::server,
+            boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        if (ec)
+        {
+            LOG_ERROR("Ssl handshake error {}", ec.message());
+            co_return;
+        }
         if constexpr (requires { router(socket); })
         {
             co_await router(socket);

--- a/src/bmcresponder.hpp
+++ b/src/bmcresponder.hpp
@@ -6,6 +6,8 @@ using namespace reactor;
 using Streamer = reactor::TimedStreamer<ssl::stream<tcp::socket>>;
 struct BmcResponder
 {
+    // Maximum allowed message size to prevent buffer overflow
+    static constexpr size_t MAX_MESSAGE_SIZE = 1024;
     ssl::context ssl;
     TcpStreamType acceptor;
     TcpServer<TcpStreamType, BmcResponder> server;
@@ -27,7 +29,7 @@ struct BmcResponder
         watcherCallback(true);
         while (true)
         {
-            std::array<char, 1024> data;
+            std::array<char, MAX_MESSAGE_SIZE> data;
             boost::system::error_code ec;
             size_t bytes{0};
             std::tie(ec, bytes) = co_await streamer.read(net::buffer(data));
@@ -38,6 +40,19 @@ struct BmcResponder
                     continue;
                 }
                 LOG_ERROR("Error reading: {}", ec.message());
+                if (watcherCallback)
+                {
+                    watcherCallback(false);
+                }
+                co_return;
+            }
+
+            // Validate message size
+            if (bytes > MAX_MESSAGE_SIZE)
+            {
+                LOG_ERROR(
+                    "Received message size {} exceeds maximum allowed size {}",
+                    bytes, MAX_MESSAGE_SIZE);
                 if (watcherCallback)
                 {
                     watcherCallback(false);


### PR DESCRIPTION
Handle TLS handshake failures gracefully in the TCP server by using redirect_error() and returning early when the handshake fails.

Also define a maximum responder message size constant and validate the received payload length before processing it. If the received message exceeds the allowed size, log the error, notify the watcher callback, and terminate the session.