### PR TITLE
bmc-pairing-manager: detect sibling disconnects reliably

### DIFF
--- a/include/socket_streams.hpp
+++ b/include/socket_streams.hpp
@@ -7,15 +7,65 @@
 #include <boost/asio/spawn.hpp>
 #include <boost/asio/streambuf.hpp>
 
+#ifdef __linux__
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#endif
+
 using namespace std::chrono_literals;
 namespace NSNAME
 {
+// Configure TCP keepalive to detect dead connections quickly.
+// Enables keepalive and, on Linux, sets aggressive probe parameters:
+//   idle time = 10s, probe interval = 5s, probe count = 3 (~25s total).
+template <typename Socket>
+inline void configureSocketKeepalive(Socket& socket)
+{
+    boost::system::error_code ec;
+    socket.set_option(boost::asio::socket_base::keep_alive(true), ec);
+    if (ec)
+    {
+        LOG_ERROR("Failed to set keepalive option: {}", ec.message());
+        return;
+    }
+    LOG_DEBUG("TCP keep-alive enabled");
+
+#ifdef __linux__
+    int native_fd = socket.native_handle();
+
+    // Start sending keepalive probes after 10 seconds of idle time
+    int keepalive_time = 10;
+    if (setsockopt(native_fd, IPPROTO_TCP, TCP_KEEPIDLE, &keepalive_time,
+                   sizeof(keepalive_time)) < 0)
+    {
+        LOG_ERROR("Failed to set TCP_KEEPIDLE");
+    }
+
+    // Send keepalive probes every 5 seconds
+    int keepalive_interval = 5;
+    if (setsockopt(native_fd, IPPROTO_TCP, TCP_KEEPINTVL, &keepalive_interval,
+                   sizeof(keepalive_interval)) < 0)
+    {
+        LOG_ERROR("Failed to set TCP_KEEPINTVL");
+    }
+
+    // Close connection after 3 failed probes (~25 seconds total)
+    int keepalive_count = 3;
+    if (setsockopt(native_fd, IPPROTO_TCP, TCP_KEEPCNT, &keepalive_count,
+                   sizeof(keepalive_count)) < 0)
+    {
+        LOG_ERROR("Failed to set TCP_KEEPCNT");
+    }
+#endif
+}
+
 struct TcpStreamType
 {
     using stream_type = boost::asio::ssl::stream<tcp::socket>;
     tcp::acceptor acceptor_;
     net::any_io_executor context;
     boost::asio::ssl::context& ssl_context_;
+
     TcpStreamType(net::any_io_executor io_context, short port,
                   boost::asio::ssl::context& ssl_context) :
         acceptor_(io_context, tcp::endpoint(tcp::v4(), port)),
@@ -37,6 +87,8 @@ struct TcpStreamType
                                    boost::system::error_code ec) {
                                    if (!ec)
                                    {
+                                       configureSocketKeepalive(
+                                           socket->lowest_layer());
                                        handler(std::move(socket));
                                    }
                                });

--- a/include/tcp_client.hpp
+++ b/include/tcp_client.hpp
@@ -12,61 +12,11 @@
 #include <string>
 #include <utility>
 
-#ifdef __linux__
-#include <netinet/tcp.h>
-#include <sys/socket.h>
-#endif
 namespace NSNAME
 {
 namespace net = boost::asio;
 namespace ssl = boost::asio::ssl;
 using tcp = boost::asio::ip::tcp;
-
-template <typename Socket>
-inline void configureSocketKeepalive(Socket& socket)
-{
-    boost::system::error_code ec;
-
-    // Enable TCP keepalive to detect dead connections
-    boost::asio::socket_base::keep_alive keepalive_option(true);
-    socket.set_option(keepalive_option, ec);
-    if (ec)
-    {
-        LOG_ERROR("Failed to set keepalive option: {}", ec.message());
-        return;
-    }
-
-#ifdef __linux__
-    // Configure aggressive TCP keepalive parameters for faster dead connection
-    // detection
-    int native_fd = socket.native_handle();
-
-    // Start sending keepalive probes after 10 seconds of idle time
-    int keepalive_time = 10;
-    if (setsockopt(native_fd, IPPROTO_TCP, TCP_KEEPIDLE, &keepalive_time,
-                   sizeof(keepalive_time)) < 0)
-    {
-        LOG_ERROR("Failed to set TCP_KEEPIDLE");
-    }
-
-    // Send keepalive probes every 5 seconds
-    int keepalive_interval = 5;
-    if (setsockopt(native_fd, IPPROTO_TCP, TCP_KEEPINTVL, &keepalive_interval,
-                   sizeof(keepalive_interval)) < 0)
-    {
-        LOG_ERROR("Failed to set TCP_KEEPINTVL");
-    }
-
-    // Close connection after 3 failed probes (total ~25 seconds to detect dead
-    // connection)
-    int keepalive_count = 3;
-    if (setsockopt(native_fd, IPPROTO_TCP, TCP_KEEPCNT, &keepalive_count,
-                   sizeof(keepalive_count)) < 0)
-    {
-        LOG_ERROR("Failed to set TCP_KEEPCNT");
-    }
-#endif
-}
 
 inline AwaitableResult<net::ip::tcp::resolver::results_type> awaitable_resolve(
     typename net::ip::tcp::resolver& resolver, const std::string& host,

--- a/src/bmcresponder.hpp
+++ b/src/bmcresponder.hpp
@@ -8,6 +8,42 @@ struct BmcResponder
 {
     // Maximum allowed message size to prevent buffer overflow
     static constexpr size_t MAX_MESSAGE_SIZE = 1024;
+
+    // Helper function to detect and log connection errors
+    static bool isConnectionError(const boost::system::error_code& ec)
+    {
+        if (!ec)
+        {
+            return false; // No error
+        }
+
+        if (ec == boost::asio::error::operation_aborted)
+        {
+            LOG_DEBUG("Operation timed out");
+            return false; // Timeout, can continue
+        }
+
+        // Detect abrupt disconnection scenarios
+        if (ec == boost::asio::error::eof)
+        {
+            LOG_INFO("Peer closed connection gracefully");
+        }
+        else if (ec == boost::asio::error::connection_reset)
+        {
+            LOG_WARNING("Peer connection reset (abrupt termination)");
+        }
+        else if (ec == boost::asio::error::broken_pipe)
+        {
+            LOG_WARNING("Broken pipe - peer disconnected abruptly");
+        }
+        else
+        {
+            LOG_ERROR("Connection error: {}", ec.message());
+        }
+
+        return true; // Fatal error, should disconnect
+    }
+
     ssl::context ssl;
     TcpStreamType acceptor;
     TcpServer<TcpStreamType, BmcResponder> server;
@@ -32,14 +68,13 @@ struct BmcResponder
             std::array<char, MAX_MESSAGE_SIZE> data;
             boost::system::error_code ec;
             size_t bytes{0};
-            std::tie(ec, bytes) = co_await streamer.read(net::buffer(data));
-            if (ec)
+            std::tie(ec, bytes) =
+                co_await streamer.read(net::buffer(data), true);
+
+            // Check for connection errors (timeouts will continue, fatal errors
+            // will disconnect)
+            if (isConnectionError(ec))
             {
-                if (ec == boost::asio::error::operation_aborted)
-                {
-                    continue;
-                }
-                LOG_ERROR("Error reading: {}", ec.message());
                 if (watcherCallback)
                 {
                     watcherCallback(false);
@@ -63,10 +98,15 @@ struct BmcResponder
             LOG_INFO("Received: {}", std::string(data.data(), bytes));
             std::string response = "alive";
             std::tie(ec, bytes) =
-                co_await streamer.write(net::buffer(response));
-            if (ec)
+                co_await streamer.write(net::buffer(response), true);
+
+            // Check for fatal connection errors during write
+            if (isConnectionError(ec))
             {
-                watcherCallback(false);
+                if (watcherCallback)
+                {
+                    watcherCallback(false);
+                }
                 co_return;
             }
         }


### PR DESCRIPTION
Enable TCP keep-alive on accepted sockets to help detect dead peers. Also update the responder connection handling to classify read and write failures. Continue on timeout, but treat EOF, connection reset, and broken pipe as peer disconnects and notify the watcher.