### PR TITLE
bmc_pairing_manager: use signal watcher for attestation state

### DIFF
--- a/src/bmc_pairing_manager.cpp
+++ b/src/bmc_pairing_manager.cpp
@@ -450,12 +450,11 @@ void setupWatchers(net::io_context& io_context,
                    std::shared_ptr<BmcResponder>& bmcResponder)
 {
     // Attestation state watcher
-    DbusPropertyWatcher<bool>::watch(
+    DbusSignalWatcher<bool>::watch(
         io_context, conn,
         std::bind_front(onSpdmStateChange, std::ref(io_context), config.port,
                         std::ref(controller), std::ref(bmcResponder)),
-        std::format(ATTESTATION_RES_PATH, config.port), ATTESTATION_RES_INTF,
-        ATTESTATION_PROP);
+        ATTESTATION_RES_INTF, ATTESTATION_RES_SIGNAL);
 
     // Neighbour discovery
     auto neighbourHandler =


### PR DESCRIPTION
Replace DbusPropertyWatcher with DbusSignalWatcher to detect the attestation "Attested" signal rather than polling the "Status" property via PropertiesChanged. This removes the dependency on the object path and property name, matching directly on the interface/signal pair.