### PR TITLE
sdbus_calls: add sdbusplus version compatibility shim

### DIFF
--- a/include/dbusproperty_watcher.hpp
+++ b/include/dbusproperty_watcher.hpp
@@ -21,7 +21,7 @@ struct DbusWatcher : std::enable_shared_from_this<Derived>
         std::function<void(boost::system::error_code, PropType)>;
     PROPERTY_HANDLER propHandler;
     std::shared_ptr<sdbusplus::asio::connection> conn;
-    std::optional<sdbusplus ::bus::match::match> match;
+    std::optional<sdbuscompat::match_t> match;
 
     DbusWatcher() = delete;
     DbusWatcher(const DbusWatcher&) = delete;

--- a/include/lldp_neighbour_handlers.hpp
+++ b/include/lldp_neighbour_handlers.hpp
@@ -46,7 +46,7 @@ auto makeNeighbourDiscoveryHandler(Handler handler,
             co_return;
         }
         reactor::InterfaceMap interfaces;
-        sdbusplus::message::object_path objPath;
+        sdbuscompat::object_path objPath;
         m->read(objPath, interfaces);
         auto it = interfaces.find(LLDP_INTF);
         if (it == interfaces.end())

--- a/include/sdbus_calls.hpp
+++ b/include/sdbus_calls.hpp
@@ -53,6 +53,31 @@
 #include <sdbusplus/exception.hpp>
 #include <sdbusplus/server.hpp>
 #include <sdbusplus/timer.hpp>
+
+// ---------------------------------------------------------------------------
+// sdbusplus version compatibility shims
+//
+// Older sdbusplus exposed:
+//   sdbusplus::message::object_path
+//   sdbusplus::bus::match::match
+//
+// Newer sdbusplus (post-2024) moved these to the top-level namespace:
+//   sdbusplus::object_path
+//   sdbusplus::match
+//
+// meson.build probes for the new API and sets -DSDBUSPLUS_NEW_API when found.
+// ---------------------------------------------------------------------------
+namespace sdbuscompat
+{
+#ifdef SDBUSPLUS_NEW_API
+using object_path = ::sdbusplus::object_path;
+using match_t = ::sdbusplus::match;
+#else
+using object_path = ::sdbusplus::message::object_path;
+using match_t = ::sdbusplus::bus::match::match;
+#endif
+} // namespace sdbuscompat
+
 namespace NSNAME
 {
 // Common D-Bus service and interface names
@@ -404,8 +429,8 @@ inline AwaitableResult<DictType> getSubTreePaths(
 template <typename DictType>
 inline AwaitableResult<DictType> getAssociatedSubTree(
     sdbusplus::asio::connection& bus,
-    const sdbusplus::message::object_path& associatedPath,
-    const sdbusplus::message::object_path& path, int depth,
+    const sdbuscompat::object_path& associatedPath,
+    const sdbuscompat::object_path& path, int depth,
     const std::vector<std::string>& interfaces = {})
 {
     return callObjectMapperMethod<DictType>(
@@ -429,8 +454,8 @@ inline AwaitableResult<DictType> getAssociatedSubTree(
 template <typename DictType>
 inline AwaitableResult<DictType> getAssociatedSubTreePaths(
     sdbusplus::asio::connection& bus,
-    const sdbusplus::message::object_path& associatedPath,
-    const sdbusplus::message::object_path& path, int32_t depth,
+    const sdbuscompat::object_path& associatedPath,
+    const sdbuscompat::object_path& path, int32_t depth,
     const std::vector<std::string>& interfaces = {})
 {
     return callObjectMapperMethod<DictType>(
@@ -548,7 +573,7 @@ inline AwaitableResult<DictType> getAssociationEndPoints(
  *
  * Example:
  * @code
- * using ManagedObjects = std::map<sdbusplus::message::object_path,
+ * using ManagedObjects = std::map<sdbuscompat::object_path,
  * InterfaceMap>; auto [ec, objects] = co_await
  * getManagedObjects<ManagedObjects>( bus,
  * "xyz.openbmc_project.Inventory.Manager",
@@ -558,7 +583,7 @@ inline AwaitableResult<DictType> getAssociationEndPoints(
 template <typename DictType>
 inline AwaitableResult<DictType> getManagedObjects(
     sdbusplus::asio::connection& bus, const std::string& service,
-    const sdbusplus::message::object_path& path)
+    const sdbuscompat::object_path& path)
 {
     co_return co_await awaitable_dbus_method_call<DictType>(
         bus, service, path, dbusObjectManagerInterface, "GetManagedObjects");
@@ -597,7 +622,7 @@ inline AwaitableResult<DictType> getAncestors(
  */
 inline AwaitableResult<std::string> introspect(
     sdbusplus::asio::connection& bus, const std::string& service,
-    const sdbusplus::message::object_path& path)
+    const sdbuscompat::object_path& path)
 {
     co_return co_await awaitable_dbus_method_call<std::string>(
         bus, service, path, dbusIntrospectableInterface, "Introspect");

--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,33 @@ openssl_dep = dependency('openssl', version: '>= 3.0', required: true)
 sdeventplus_dep = dependency('sdeventplus')
 sdbusplus_dep =dependency('sdbusplus')
 dbus_interfaces_dep =dependency('phosphor-dbus-interfaces')
+
+# ---------------------------------------------------------------------------
+# sdbusplus version detection
+#
+# New sdbusplus (post-2024) promotes object_path and match to the top-level
+# sdbusplus namespace.  Older versions keep them under sdbusplus::message and
+# sdbusplus::bus::match respectively.
+#
+# We probe for sdbusplus::object_path (the new-API sentinel).  When found we
+# define SDBUSPLUS_NEW_API so the compat shim in sdbus_calls.hpp resolves to
+# the correct types automatically.
+# ---------------------------------------------------------------------------
+cxx = meson.get_compiler('cpp')
+# Probe for sdbusplus::match at the top-level namespace.
+# This type only exists in the new sdbusplus API (post-2024).
+# Older releases only have sdbusplus::bus::match::match.
+if cxx.has_type(
+    'sdbusplus::match',
+    prefix: '#include <sdbusplus/bus/match.hpp>',
+    dependencies: sdbusplus_dep,
+)
+    add_project_arguments('-DSDBUSPLUS_NEW_API', language: 'cpp')
+    message('sdbusplus: new API detected (sdbusplus::match / sdbusplus::object_path)')
+else
+    message('sdbusplus: old API detected (sdbusplus::bus::match::match / sdbusplus::message::object_path)')
+endif
+
 bmc_pairing_manager_dep = declare_dependency(
     dependencies:[sdbusplus_dep,sdeventplus_dep,openssl_dep,boost_dep,dbus_interfaces_dep],
     include_directories:['include']


### PR DESCRIPTION
Newer sdbusplus (post-2024) promotes object_path and match to the top-level namespace (sdbusplus::object_path, sdbusplus::match), while older releases keep them under sdbusplus::message::object_path and sdbusplus::bus::match::match respectively.

Introduce the sdbuscompat namespace in sdbus_calls.hpp that resolves to the correct types at compile time:

  namespace sdbuscompat {
    using object_path = ...;
    using match_t     = ...;
  }

meson.build probes for sdbusplus::match at the top-level namespace. When found it sets -DSDBUSPLUS_NEW_API, causing sdbuscompat to alias the new types; otherwise it aliases the legacy types.

Replace all direct uses of sdbusplus::message::object_path and sdbusplus::bus::match::match in sdbus_calls.hpp,
dbusproperty_watcher.hpp, and lldp_neighbour_handlers.hpp with the sdbuscompat aliases so the code builds against both old and new sdbusplus without any runtime overhead.

Tested: builds successfully against both sdbusplus old and new API.