### PR TITLE
bmc-pairing-manager: use production cert paths and set peer hostname

### DIFF
--- a/src/bmc_pairing_manager_object.hpp
+++ b/src/bmc_pairing_manager_object.hpp
@@ -40,7 +40,7 @@ struct BmcPairingManagerObject : Ifaces
     PROVISIONING_HANDLER provisionHandler;
 
     static constexpr auto busName = "xyz.openbmc_project.BmcPairingManager";
-    static constexpr auto objPath = "/xyz/openbmc_project/BmcPairingManager";
+    static constexpr auto objPath = Provisioning::instance_path;
     static constexpr auto interface = Provisioning::interface;
 
     BmcPairingManagerObject() = delete;

--- a/src/ssl_functions.hpp
+++ b/src/ssl_functions.hpp
@@ -2,28 +2,29 @@
 #include <boost/asio.hpp>
 
 #include <filesystem>
-static std::string cert_root = "/tmp/1222";
+#include <format>
+#include <string>
 using namespace reactor;
 namespace fs = std::filesystem;
 inline std::string trustStorePath()
 {
-    return std::format("{}etc/ssl/certs/authority", cert_root);
+    return "/etc/ssl/certs/authority";
 }
 inline std::string ENTITY_CLIENT_CERT_PATH()
 {
-    return std::format("{}etc/ssl/certs/https/client_cert.pem", cert_root);
+    return "/etc/ssl/certs/https/client_cert.pem";
 }
 inline std::string CLIENT_PKEY_PATH()
 {
-    return std::format("{}etc/ssl/private/client_pkey.pem", cert_root);
+    return "/etc/ssl/private/client_pkey.pem";
 }
 inline std::string ENTITY_SERVER_CERT_PATH()
 {
-    return std::format("{}etc/ssl/certs/https/server_cert.pem", cert_root);
+    return "/etc/ssl/certs/https/server_cert.pem";
 }
 inline std::string SERVER_PKEY_PATH()
 {
-    return std::format("{}etc/ssl/private/server_pkey.pem", cert_root);
+    return "/etc/ssl/private/server_pkey.pem";
 }
 std::optional<ssl::context> getClientContext()
 {

--- a/subdir/attestationd/src/attestation.cpp
+++ b/subdir/attestationd/src/attestation.cpp
@@ -234,7 +234,7 @@ int main(int argc, const char* argv[])
             LOG_ERROR("Failed to load signing certificate from {}", signcert);
             return 1;
         }
-        CertificateExchanger::createCertificates();
+        CertificateExchanger::createCertificates("bmc.peer");
         AttestationHandler attestationHandler(
             MeasurementTaker(loadPrivateKey(signprivkey)),
             MeasurementVerifier(getPublicKeyFromCert(verifyCert)), eventQueue,

--- a/subdir/attestationd/src/certificate_exchange.hpp
+++ b/subdir/attestationd/src/certificate_exchange.hpp
@@ -246,7 +246,7 @@ struct CertificateExchanger
 
     static bool processInterMediateCA(
         const openssl_ptr<EVP_PKEY, EVP_PKEY_free>& pkey,
-        const openssl_ptr<X509, X509_free>& ca)
+        const openssl_ptr<X509, X509_free>& ca, const std::string& hostName)
     {
         if (!pkey)
         {
@@ -267,8 +267,8 @@ struct CertificateExchanger
                         ENTITY_SERVER_COMBINED_PATH()}};
         auto caname = openssl_ptr<X509_NAME, X509_NAME_free>(
             X509_NAME_dup(X509_get_subject_name(ca.get())), X509_NAME_free);
-        auto servCert = createAndSaveEntityCertificate<2>(
-            pkey, ca, "BMC Entity", entity_data, 1);
+        auto servCert = createAndSaveEntityCertificate<2>(pkey, ca, hostName,
+                                                          entity_data, 1);
         if (!servCert)
         {
             LOG_ERROR("Failed to create server entity certificate");
@@ -320,7 +320,7 @@ struct CertificateExchanger
             trustStoreDir);
         return true;
     }
-    static X509Ptr createCertificates()
+    static X509Ptr createCertificates(const std::string& hostName = {})
     {
         if (fs::exists(SELF_CA_PATH()))
         {
@@ -332,7 +332,7 @@ struct CertificateExchanger
             LOG_ERROR("Failed to create CA certificate and private key");
             return makeX509Ptr(nullptr);
         }
-        if (!processInterMediateCA(ca_pkey, ca_cert))
+        if (!processInterMediateCA(ca_pkey, ca_cert, hostName))
         {
             LOG_ERROR("Failed to process intermediate CA");
             return makeX509Ptr(nullptr);


### PR DESCRIPTION
Replace the debug cert_root prefix (/tmp/1222) in ssl_functions.hpp with hardcoded production paths (/etc/ssl/...). Use Provisioning::instance_path for the D-Bus object path instead of a duplicated string literal. Pass the peer hostname ("bmc.peer") through createCertificates/processInterMediateCA so the entity certificate CN reflects the actual peer identity rather than the hardcoded "BMC Entity" string.

Add a new lldp-hosts-updater subproject with a meson.options toggle (lldp_hosts_updater) and a configurable interface option (lldp_hosts_updater_iface, default eth2); wire it into subdir/meson.build.