### PR TITLE
cert_generator: use 64-bit random serial number

### DIFF
--- a/include/cert_generator.hpp
+++ b/include/cert_generator.hpp
@@ -19,7 +19,9 @@
 
 #include <fstream>
 #include <iterator>
+#include <limits>
 #include <memory>
+#include <random>
 #include <string>
 #include <vector>
 namespace NSNAME
@@ -717,7 +719,11 @@ inline openssl_ptr<X509, X509_free> create_certificate(
         return makeX509Ptr(nullptr);
     }
     openssl_ptr<X509, X509_free> cert(X509_new(), X509_free);
-    ASN1_INTEGER_set(X509_get_serialNumber(cert.get()), std::rand());
+    std::random_device rd;
+    std::mt19937_64 gen(rd());
+    std::uniform_int_distribution<uint64_t> dis(
+        1, std::numeric_limits<uint64_t>::max());
+    ASN1_INTEGER_set_uint64(X509_get_serialNumber(cert.get()), dis(gen));
     
     // Set notBefore to Unix epoch (January 1, 1970, 00:00:00 UTC) for maximum validity
     // This allows the certificate to be valid from the earliest possible date


### PR DESCRIPTION
Replace std::rand() with a std::mt19937_64 PRNG seeded from std::random_device, and switch from ASN1_INTEGER_set() to ASN1_INTEGER_set_uint64() to support the full 64-bit range.

The previous implementation used std::rand(), which only provides 31-bit entropy on most platforms and can produce negative values when cast to long. This change generates a cryptographically stronger serial number in the range [1, 2^64-1], satisfying RFC 5280 requirements for positive serial numbers.

Tested: Verified certificate generation creates unique 64-bit
        serial numbers.