### PR TITLE
lldp-hosts-updater: add LLDP-to-/etc/hosts daemon

### DIFF
--- a/include/lldp_neighbour_handlers.hpp
+++ b/include/lldp_neighbour_handlers.hpp
@@ -61,7 +61,7 @@ auto makeNeighbourDiscoveryHandler(Handler handler,
                 propMap, "ManagementAddressIPv4", "SystemName");
         if (ec1)
         {
-            LOG_ERROR("Failed to get LLDP properties: {}", ec.message());
+            LOG_ERROR("Failed to get LLDP properties: {}", ec1.message());
             co_return;
         }
         if (address.empty() || name.empty())

--- a/meson.options
+++ b/meson.options
@@ -6,6 +6,20 @@ option(
 )
 
 option(
+    'lldp_hosts_updater',
+    type: 'boolean',
+    description: 'Build lldp-hosts-updater: watches LLDP for peer IP and writes /etc/hosts',
+    value: false,
+)
+
+option(
+    'lldp_hosts_updater_iface',
+    type: 'string',
+    description: 'Network interface to watch for LLDP neighbours',
+    value: 'eth2',
+)
+
+option(
     'pingtest',
     type: 'boolean',
     description: 'Enables pingtest tool',

--- a/subdir/lldp-hosts-updater/include/hosts_updater.hpp
+++ b/subdir/lldp-hosts-updater/include/hosts_updater.hpp
@@ -1,0 +1,94 @@
+#pragma once
+
+#include "logger.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+inline constexpr auto PEER_HOSTNAME = "bmc.peer";
+inline constexpr auto ETC_HOSTS_PATH = "/etc/hosts";
+
+/**
+ * @brief Write or overwrite the bmc.peer entry in /etc/hosts.
+ *
+ * Reads the current /etc/hosts, removes any existing line that already
+ * maps to PEER_HOSTNAME, appends the new mapping, then atomically replaces
+ * the file by writing to a temp path and renaming.
+ *
+ * @param ip  The IPv4 (or IPv6) address to map to bmc.peer.
+ * @return true on success, false on any I/O failure.
+ */
+inline bool updateEtcHosts(const std::string& ip)
+{
+    const std::string hostsPath = ETC_HOSTS_PATH;
+    const std::string tmpPath = std::string(ETC_HOSTS_PATH) + ".tmp";
+
+    // Read existing content, stripping any previous bmc.peer line.
+    std::vector<std::string> lines;
+    {
+        std::ifstream in(hostsPath);
+        if (in.is_open())
+        {
+            // Collect all lines that do NOT contain PEER_HOSTNAME as a token.
+            auto noPeer = [](const std::string& line) {
+                std::istringstream iss(line);
+                std::string tok;
+                while (iss >> tok)
+                {
+                    if (tok == PEER_HOSTNAME)
+                        return false;
+                }
+                return true;
+            };
+
+            std::string line;
+            while (std::getline(in, line))
+            {
+                if (noPeer(line))
+                {
+                    lines.push_back(line);
+                }
+            }
+        }
+    }
+
+    // Append the fresh entry.
+    lines.push_back(ip + "\t" + PEER_HOSTNAME);
+
+    // Write to a temp file then rename for atomicity.
+    {
+        std::ofstream out(tmpPath);
+        if (!out.is_open())
+        {
+            LOG_ERROR("Failed to open {} for writing", tmpPath);
+            return false;
+        }
+        for (const auto& line : lines)
+        {
+            out << line << '\n';
+        }
+        out.close();
+        if (!out)
+        {
+            std::error_code removeEc;
+            std::filesystem::remove(tmpPath, removeEc);
+            LOG_ERROR("Write/close error on {}", tmpPath);
+            return false;
+        }
+    }
+
+    std::error_code ec;
+    std::filesystem::rename(tmpPath, hostsPath, ec);
+    if (ec)
+    {
+        LOG_ERROR("Failed to rename {} -> {}: {}", tmpPath, hostsPath,
+                  ec.message());
+        return false;
+    }
+
+    LOG_INFO("Updated {}: {} -> {}", hostsPath, ip, PEER_HOSTNAME);
+    return true;
+}

--- a/subdir/lldp-hosts-updater/meson.build
+++ b/subdir/lldp-hosts-updater/meson.build
@@ -1,0 +1,19 @@
+executable(
+    'lldp-hosts-updater',
+    'src/lldp_hosts_updater.cpp',
+    dependencies: [bmc_pairing_manager_dep],
+    cpp_args: ['-DBOOST_ASIO_DISABLE_THREADS'],
+    include_directories: ['include'],
+    install: true,
+    install_dir: '/usr/bin',
+)
+
+configure_file(
+    input: 'service/xyz.openbmc_project.lldp-hosts-updater.service.in',
+    output: 'xyz.openbmc_project.lldp-hosts-updater.service',
+    configuration: {
+        'IFACE': get_option('lldp_hosts_updater_iface'),
+    },
+    install: true,
+    install_dir: dependency('systemd').get_variable('systemdsystemunitdir'),
+)

--- a/subdir/lldp-hosts-updater/service/xyz.openbmc_project.lldp-hosts-updater.service.in
+++ b/subdir/lldp-hosts-updater/service/xyz.openbmc_project.lldp-hosts-updater.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=LLDP neighbour /etc/hosts updater
+After=xyz.openbmc_project.LLDP.service
+Wants=xyz.openbmc_project.LLDP.service
+
+[Service]
+ExecStart=/usr/bin/lldp-hosts-updater -i @IFACE@
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/subdir/lldp-hosts-updater/src/lldp_hosts_updater.cpp
+++ b/subdir/lldp-hosts-updater/src/lldp_hosts_updater.cpp
@@ -1,0 +1,87 @@
+// Watches the LLDP neighbour D-Bus interface for a management IP address
+// and writes/overwrites a "bmc.peer <ip>" entry in /etc/hosts so that
+// systemd-resolved resolves the peer by name without a DNS lookup.
+
+#include "command_line_parser.hpp"
+#include "hosts_updater.hpp"
+#include "lldp_neighbour_handlers.hpp"
+#include "logger.hpp"
+#include "sdbus_calls.hpp"
+
+#include <boost/asio.hpp>
+#include <sdbusplus/asio/connection.hpp>
+#include <sdbusplus/bus/match.hpp>
+
+#include <format>
+#include <string>
+
+namespace net = boost::asio;
+using namespace reactor;
+
+static constexpr auto DEFAULT_IFACE = "eth2";
+
+/**
+ * @brief Coroutine called each time a neighbour IP is discovered via LLDP.
+ *
+ * Updates /etc/hosts with the new IP → bmc.peer mapping and continues
+ * watching so future address changes are also applied.
+ */
+static net::awaitable<void> onNeighbourFound(const std::string& address,
+                                             const std::string& /*name*/)
+{
+    LOG_INFO("LLDP neighbour discovered: {}", address);
+    if (!updateEtcHosts(address))
+    {
+        LOG_ERROR("Failed to update /etc/hosts with address {}", address);
+    }
+    co_return;
+}
+
+int main(int argc, const char* argv[])
+{
+    try
+    {
+        auto [iface] = getArgs(parseCommandline(argc, argv), "--iface,-i");
+        std::string ifaceName = iface ? std::string(*iface) : DEFAULT_IFACE;
+
+        auto& logger = getLogger();
+        logger.setLogLevel(LogLevel::INFO);
+
+        net::io_context io_context;
+        auto conn = std::make_shared<sdbusplus::asio::connection>(io_context);
+
+        auto neighbourHandler =
+            [](const std::string& address,
+               const std::string& name) -> net::awaitable<void> {
+            co_await onNeighbourFound(address, name);
+        };
+
+        auto fallbackHandler =
+            makeNeighbourUpdateHandler(conn, ifaceName, neighbourHandler);
+
+        // Subscribe to future InterfacesAdded signals on the LLDP receive path.
+        DbusSignalWatcher<sdbusplus::message_t>::watch(
+            io_context, conn,
+            makeNeighbourDiscoveryHandler(neighbourHandler,
+                                          std::move(fallbackHandler)),
+            sdbusplus::bus::match::rules::interfacesAddedAtPath(
+                std::format(LLDP_REC_PATH, ifaceName)));
+
+        // Also trigger an initial poll so an already-present neighbour is
+        // handled.
+        net::co_spawn(
+            io_context,
+            makeNeighbourUpdateHandler(conn, ifaceName, neighbourHandler),
+            net::detached);
+
+        LOG_INFO("lldp-hosts-updater started, watching interface {}",
+                 ifaceName);
+        io_context.run();
+    }
+    catch (const std::exception& e)
+    {
+        LOG_ERROR("Fatal error: {}", e.what());
+        return 1;
+    }
+    return 0;
+}

--- a/subdir/meson.build
+++ b/subdir/meson.build
@@ -1,3 +1,7 @@
 if (get_option('attestation_stub') == true)
     subdir('attestationd')
 endif
+
+if (get_option('lldp_hosts_updater') == true)
+    subdir('lldp-hosts-updater')
+endif


### PR DESCRIPTION
Add a new optional sub-component, lldp-hosts-updater, that watches the D-Bus LLDP neighbour interface for a peer management IP address and writes a "bmc.peer <ip>" entry to /etc/hosts so the peer BMC is resolvable by name without a DNS lookup.

Changes:
- subdir/lldp-hosts-updater/include/hosts_updater.hpp: atomic /etc/hosts writer that strips any previous bmc.peer mapping before appending the updated entry via a rename(2) for atomicity.
- subdir/lldp-hosts-updater/src/lldp_hosts_updater.cpp: main entry point; subscribes to InterfacesAdded signals on the LLDP receive path and performs an initial poll at startup for already-present neighbours.
- subdir/lldp-hosts-updater/service/*.service.in: systemd unit that starts after xyz.openbmc_project.LLDP.service with the watched interface configurable at build time.
- subdir/lldp-hosts-updater/meson.build: build rules for the executable and systemd service installation.
- meson.options: two new build options – lldp_hosts_updater (boolean, default false) and lldp_hosts_updater_iface (string, default eth2).
- subdir/meson.build: wire the new subdir under the lldp_hosts_updater option guard.